### PR TITLE
feat : 리뷰 상세 보기 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -109,11 +109,10 @@ jobs:
         password: ${{ secrets.EC2_PW }} 
         port: ${{ secrets.PORT }}
         script: |
-          docker-compose down
           sudo docker rm -f $(docker ps -qa)
           sudo docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
           sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
-          docker-compose up -d
+          nohup docker-compose up -d
           docker image prune -f
 
   ## Connect to Slack

--- a/src/main/java/com/example/seatchoice/config/SecurityConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
 			.csrf().disable()
 			.authorizeRequests()
 			.antMatchers(
-				"/api/auth/login"
+				"/api/auth/login", "/api/**"
 			).permitAll()
 			.anyRequest().authenticated();
 

--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -2,11 +2,13 @@ package com.example.seatchoice.controller;
 
 import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.dto.cond.ReviewCond;
+import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.param.ReviewParam;
 import com.example.seatchoice.service.ReviewService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,15 +27,21 @@ public class ReviewController {
 	// 리뷰등록
 	// TODO
 	// 로그인 된 user 정보 가져오기
-	@PostMapping("/theater-seats/{seatId}/reviews")
+	@PostMapping("/theaters/{theaterId}/reviews")
 	public ApiResponse<ReviewCond> createReview(
-		@PathVariable Long seatId,
+		@PathVariable Long theaterId,
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
 		@RequestPart("data") ReviewParam request) {
 
 		// image file을 선택하지 않았을 때
 		if (files.get(0).getSize() == 0) files = null;
-		ReviewCond reviewCond = reviewService.createReview(seatId, files, request);
+		ReviewCond reviewCond = reviewService.createReview(theaterId, files, request);
 		return new ApiResponse<>(reviewCond);
+	}
+
+	// 리뷰 상세보기
+	@GetMapping("/reviews/{reviewId}")
+	public ApiResponse<ReviewInfoCond> getReview(@PathVariable Long reviewId) {
+		return new ApiResponse<>(reviewService.getReview(reviewId));
 	}
 }

--- a/src/main/java/com/example/seatchoice/dto/common/ErrorResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/common/ErrorResponse.java
@@ -3,10 +3,12 @@ package com.example.seatchoice.dto.common;
 import com.example.seatchoice.type.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @Builder
+@Getter
 @AllArgsConstructor
 public class ErrorResponse {
 

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -1,0 +1,43 @@
+package com.example.seatchoice.dto.cond;
+
+import com.example.seatchoice.entity.Review;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewInfoCond {
+	private String nickname;
+	private LocalDateTime createdAt;
+	private Integer floor;
+	private String section;
+	private String row;
+	private Integer seatNumber;
+	private Double rating; // 평점
+	private Integer likeAmount; // 좋아요 개수
+	private String content;
+	private List<String> images;
+
+
+	public static ReviewInfoCond from(Review review, Double rating,
+		Integer likeAmount, List<String> images) {
+		return ReviewInfoCond.builder()
+			.nickname(review.getMember().getNickname())
+			.createdAt(review.getMember().getCreatedAt())
+			.floor(review.getTheaterSeat().getFloor())
+			.section(review.getTheaterSeat().getSection())
+			.row(review.getTheaterSeat().getSeatRow())
+			.seatNumber(review.getTheaterSeat().getNumber())
+			.rating(rating)
+			.likeAmount(likeAmount)
+			.content(review.getContent())
+			.images(images)
+			.build();
+	}
+}

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewInfoCond {
+	private Long userId;
 	private String nickname;
 	private LocalDateTime createdAt;
 	private Integer floor;
@@ -28,6 +29,7 @@ public class ReviewInfoCond {
 	public static ReviewInfoCond from(Review review, Double rating,
 		Integer likeAmount, List<String> images) {
 		return ReviewInfoCond.builder()
+			.userId(review.getMember().getId())
 			.nickname(review.getMember().getNickname())
 			.createdAt(review.getMember().getCreatedAt())
 			.floor(review.getTheaterSeat().getFloor())

--- a/src/main/java/com/example/seatchoice/repository/ImageRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ImageRepository.java
@@ -1,10 +1,11 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.Image;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
-
+	List<Image> findAllByReviewId(Long id);
 }

--- a/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
@@ -1,0 +1,9 @@
+package com.example.seatchoice.repository;
+
+import com.example.seatchoice.entity.ReviewLike;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+	List<ReviewLike> findAllByReviewId(Long id);
+}

--- a/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
@@ -1,10 +1,11 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-
+	List<Review> findAllByTheaterSeatId(Long id);
 }

--- a/src/main/java/com/example/seatchoice/repository/TheaterSeatRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/TheaterSeatRepository.java
@@ -1,10 +1,11 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.TheaterSeat;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TheaterSeatRepository extends JpaRepository<TheaterSeat, Long> {
-
+	List<TheaterSeat> findAllByTheaterId(Long id);
 }

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -108,6 +108,7 @@ public class ReviewService {
 		throw new CustomException(ErrorCode.NOT_FOUND_SEAT, HttpStatus.BAD_REQUEST);
 	}
 
+	// 좌석 평점
 	public Double getReviewRating(Long theaterSeatId) {
 		List<Review> reviews = reviewRepository.findAllByTheaterSeatId(theaterSeatId);
 		Double total = 0.0;
@@ -117,6 +118,7 @@ public class ReviewService {
 		return Math.round((total / reviews.size()) * 10) / 10.0;
 	}
 
+	// 좌석 좋아요 개수
 	public Integer getLikeAmount(Long reviewId) {
 		List<ReviewLike> reviewLikes = reviewLikeRepository.findAllByReviewId(reviewId);
 		if (CollectionUtils.isEmpty(reviewLikes)) return 0;

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -16,7 +16,6 @@ import com.example.seatchoice.type.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -24,7 +23,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ReviewService {
 
 	private final ReviewRepository reviewRepository;

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -89,6 +89,7 @@ public class ReviewService {
 			getLikeAmount(reviewId), images);
 	}
 
+	// 리뷰 등록 시 등록한 좌석 정보로 해당 공연장 좌석 받아오기
 	public TheaterSeat getTheaterSeat(List<TheaterSeat> theaterSeats, ReviewParam request) {
 		for (TheaterSeat seat : theaterSeats) {
 			if (seat.getFloor() == request.getFloor() &&

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -1,17 +1,22 @@
 package com.example.seatchoice.service;
 
 import com.example.seatchoice.dto.cond.ReviewCond;
+import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.param.ReviewParam;
 import com.example.seatchoice.entity.Image;
 import com.example.seatchoice.entity.Review;
+import com.example.seatchoice.entity.ReviewLike;
 import com.example.seatchoice.entity.TheaterSeat;
 import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.repository.ImageRepository;
+import com.example.seatchoice.repository.ReviewLikeRepository;
 import com.example.seatchoice.repository.ReviewRepository;
 import com.example.seatchoice.repository.TheaterSeatRepository;
 import com.example.seatchoice.type.ErrorCode;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -19,22 +24,24 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewService {
 
 	private final ReviewRepository reviewRepository;
 	private final ImageRepository imageRepository;
 	private final TheaterSeatRepository theaterSeatRepository;
+	private final ReviewLikeRepository reviewLikeRepository;
 	private final ImageService s3Service;
 
 
-	public ReviewCond createReview(Long seatId, List<MultipartFile> files, ReviewParam request) {
+	// 리뷰 등록
+	public ReviewCond createReview(Long theaterId, List<MultipartFile> files, ReviewParam request) {
 		// TODO 로그인 된 유저 검증
 
-		TheaterSeat theaterSeat = theaterSeatRepository.findById(seatId)
-			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEAT, HttpStatus.BAD_REQUEST));
+		List<TheaterSeat> theaterSeats = theaterSeatRepository.findAllByTheaterId(theaterId);
+		TheaterSeat theaterSeat = getTheaterSeat(theaterSeats, request);
 
 		List<String> images = s3Service.uploadImage(files);
-
 		String thumbnail = null;
 		if (!CollectionUtils.isEmpty(images)) {
 			thumbnail = images.get(0);
@@ -49,7 +56,7 @@ public class ReviewService {
 				.build()
 		);
 
-		if (!CollectionUtils.isEmpty(images)) {
+		if (thumbnail != null) {
 			for (String img : images) {
 				imageRepository.save(
 					Image.builder()
@@ -60,5 +67,59 @@ public class ReviewService {
 		}
 
 		return ReviewCond.from(review, images);
+	}
+
+	// 리뷰 상세 조회
+	public ReviewInfoCond getReview(Long reviewId) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW, HttpStatus.BAD_REQUEST));
+
+		List<Image> imageList = imageRepository.findAllByReviewId(reviewId);
+		List<String> images = new ArrayList<>();
+		if (!CollectionUtils.isEmpty(imageList)) {
+			for (int i = 0; i < imageList.size(); i++) {
+				images.add(imageList.get(i).getUrl());
+			}
+		} else {
+			imageList = null;
+		}
+
+		return ReviewInfoCond.from(review, getReviewRating(review.getTheaterSeat().getId()),
+			getLikeAmount(reviewId), images);
+	}
+
+	public TheaterSeat getTheaterSeat(List<TheaterSeat> theaterSeats, ReviewParam request) {
+		for (TheaterSeat seat : theaterSeats) {
+			if (seat.getFloor() == request.getFloor() &&
+				seat.getSeatRow().equals(request.getSeatRow()) &&
+				seat.getNumber() == request.getSeatNumber()) {
+				if (seat.getSection() == null && request.getSection() == null) {
+					return seat;
+				} else if (seat.getSection() != null && request.getSection() != null) {
+					if (seat.getSection().equals(request.getSection())) {
+						return seat;
+					}
+				}
+			}
+		}
+
+		// 해당 좌석이 없을 때
+		throw new CustomException(ErrorCode.NOT_FOUND_SEAT, HttpStatus.BAD_REQUEST);
+	}
+
+	public Double getReviewRating(Long theaterSeatId) {
+		List<Review> reviews = reviewRepository.findAllByTheaterSeatId(theaterSeatId);
+		Double total = 0.0;
+		for (int i = 0; i < reviews.size(); i++) {
+			total += reviews.get(i).getRating();
+		}
+		return Math.round((total / reviews.size()) * 10) / 10.0;
+	}
+
+	public Integer getLikeAmount(Long reviewId) {
+		List<ReviewLike> reviewLikes = reviewLikeRepository.findAllByReviewId(reviewId);
+		if (CollectionUtils.isEmpty(reviewLikes)) return 0;
+		return reviewLikes.size();
 	}
 }

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
 	NOT_FOUND_THEATER("해당 공연장이 존재하지 않습니다."),
 	NOT_FOUND_CHATROOM("해당 채팅방이 존재하지 않습니다."),
 	NOT_FOUND_SEAT("해당 공연좌석이 존재하지 않습니다."),
-	NOT_FOUND_REVIEW("해당 리뷰기 존재하지 않습니다."),
+	NOT_FOUND_REVIEW("해당 리뷰가 존재하지 않습니다."),
 	IMAGE_UPLOAD_FAIL("이미지 업로드에 실패했습니다."),
 	WRONG_FILE_FORM("잘못된 형식의 파일입니다."),
 	ERROR_CODE_500("서버 에러. 문의가 필요합니다.")

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	NOT_FOUND_THEATER("해당 공연장이 존재하지 않습니다."),
 	NOT_FOUND_CHATROOM("해당 채팅방이 존재하지 않습니다."),
 	NOT_FOUND_SEAT("해당 공연좌석이 존재하지 않습니다."),
+	NOT_FOUND_REVIEW("해당 리뷰기 존재하지 않습니다."),
 	IMAGE_UPLOAD_FAIL("이미지 업로드에 실패했습니다."),
 	WRONG_FILE_FORM("잘못된 형식의 파일입니다."),
 	ERROR_CODE_500("서버 에러. 문의가 필요합니다.")


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 리뷰 상세 보기 구현
- securityconfig path에 /api/** 추가하여 배포 시 url 잘 작동하는지 확인하고자 합니다!
- gradle.yml 에서 docker-compose up -d -> nohup docker-compose up -d
=> ec2 로그아웃 되어도 서버 잘 돌아가도록 설정
- api url에서 좌석에 대한 id를 받아오지 못 하고,  공연장 id만 받아올 수 있기 때문에
리뷰와 공연장 좌석 간 연결이 매끄럽지 못 할 수 있어서 service의 getReview 부분 로직 확인해주세요! 

**TO-BE**
- 리뷰 삭제 구현
- 로그인 구현 완료 시 로직 추가하여 테스트 코드 작성할 예정

### 테스트 
- [ ] 테스트 코드
- [x] API 테스트 
