### PR TITLE
feat : 리뷰 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {  // querydsl
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.7'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.example'
@@ -51,6 +58,10 @@ dependencies {
 	// aws
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}" // querydsl 라이브러리
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -68,4 +79,23 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// qeurydsl
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/example/seatchoice/config/QueryDslConfig.java
+++ b/src/main/java/com/example/seatchoice/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.seatchoice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -3,16 +3,20 @@ package com.example.seatchoice.controller;
 import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.dto.cond.ReviewCond;
 import com.example.seatchoice.dto.cond.ReviewDetailCond;
+import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.param.ReviewParam;
 import com.example.seatchoice.service.ReviewService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,6 +48,14 @@ public class ReviewController {
 	@GetMapping("/reviews/{reviewId}")
 	public ApiResponse<ReviewDetailCond> getReview(@PathVariable Long reviewId) {
 		return new ApiResponse<>(reviewService.getReview(reviewId));
+	}
+
+	// 리뷰 목록 조회 (무한스크롤)
+	@GetMapping("/reviews")
+	public ApiResponse<Slice<ReviewInfoCond>> getReviews(
+		@RequestParam(required = false) Long lastReviewId,
+		@RequestParam Long seatId, Pageable pageable) {
+		return new ApiResponse<>(reviewService.getReviews(lastReviewId, seatId, pageable));
 	}
 
 	// 리뷰 삭제

--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.param.ReviewParam;
 import com.example.seatchoice.service.ReviewService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +37,7 @@ public class ReviewController {
 	public ApiResponse<ReviewCond> createReview(
 		@PathVariable Long theaterId,
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
-		@RequestPart("data") ReviewParam request) {
+		@Valid @RequestPart("data") ReviewParam request) {
 
 		// image file을 선택하지 않았을 때
 		if (files.get(0).getSize() == 0) files = null;

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
@@ -21,13 +21,12 @@ public class ReviewDetailCond {
 	private String row;
 	private Integer seatNumber;
 	private Double rating; // 평점
-	private Integer likeAmount; // 좋아요 개수
+	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private List<String> images;
 
 
-	public static ReviewDetailCond from(Review review, Double rating,
-		Integer likeAmount, List<String> images) {
+	public static ReviewDetailCond from(Review review, Double rating, List<String> images) {
 		return ReviewDetailCond.builder()
 			.userId(review.getMember().getId())
 			.nickname(review.getMember().getNickname())
@@ -37,7 +36,7 @@ public class ReviewDetailCond {
 			.row(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
 			.rating(rating)
-			.likeAmount(likeAmount)
+			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.images(images)
 			.build();

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -23,10 +23,10 @@ public class ReviewInfoCond {
 	private String row;
 	private Integer seatNumber;
 	private Double rating; // 평점
-	private Integer likeAmount; // 좋아요 개수
+	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private String thumbnail;
-	private Integer commentAmount;
+	private Long commentAmount;
 
 	public static ReviewInfoCond from(Review review) {
 		return ReviewInfoCond.builder()
@@ -37,10 +37,10 @@ public class ReviewInfoCond {
 			.row(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
 			.rating(null)
-			.likeAmount(null)
+			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.thumbnail(review.getThumbnailUrl())
-			.commentAmount(null)
+			.commentAmount(review.getCommentAmount())
 			.build();
 	}
 

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -1,21 +1,23 @@
 package com.example.seatchoice.dto.cond;
 
 import com.example.seatchoice.entity.Review;
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.util.CollectionUtils;
 
+@Setter
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewInfoCond {
+	private Long reviewId;
 	private Long userId;
-	private String nickname;
-	private LocalDateTime createdAt;
 	private Integer floor;
 	private String section;
 	private String row;
@@ -23,23 +25,31 @@ public class ReviewInfoCond {
 	private Double rating; // 평점
 	private Integer likeAmount; // 좋아요 개수
 	private String content;
-	private List<String> images;
+	private String thumbnail;
+	private Integer commentAmount;
 
-
-	public static ReviewInfoCond from(Review review, Double rating,
-		Integer likeAmount, List<String> images) {
+	public static ReviewInfoCond from(Review review) {
 		return ReviewInfoCond.builder()
+			.reviewId(review.getId())
 			.userId(review.getMember().getId())
-			.nickname(review.getMember().getNickname())
-			.createdAt(review.getMember().getCreatedAt())
 			.floor(review.getTheaterSeat().getFloor())
 			.section(review.getTheaterSeat().getSection())
 			.row(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
-			.rating(rating)
-			.likeAmount(likeAmount)
+			.rating(null)
+			.likeAmount(null)
 			.content(review.getContent())
-			.images(images)
+			.thumbnail(review.getThumbnailUrl())
+			.commentAmount(null)
 			.build();
+	}
+
+	public static List<ReviewInfoCond> of(List<Review> reviews) {
+		if (CollectionUtils.isEmpty(reviews)) {
+			return null;
+		}
+		return reviews.stream()
+			.map(ReviewInfoCond::from)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/example/seatchoice/dto/param/ReviewParam.java
+++ b/src/main/java/com/example/seatchoice/dto/param/ReviewParam.java
@@ -1,9 +1,9 @@
 package com.example.seatchoice.dto.param;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,16 +16,15 @@ import lombok.Setter;
 public class ReviewParam {
 
 	@NotNull(message = "필수 입력입니다.")
+	@Positive(message = "1층 이상을 입력해주세요")
 	private Integer floor;
 
 	private String section;
 
 	@NotBlank(message = "필수 입력입니다.")
-	@JsonProperty("seat_row")
 	private String seatRow;
 
 	@NotNull(message = "필수 입력입니다.")
-	@JsonProperty("seat_number")
 	private Integer seatNumber;
 
 	@NotBlank(message = "필수 입력입니다.")

--- a/src/main/java/com/example/seatchoice/dto/validation/ValidErrorResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/validation/ValidErrorResponse.java
@@ -1,0 +1,33 @@
+package com.example.seatchoice.dto.validation;
+
+import com.example.seatchoice.dto.common.ErrorResponse;
+import com.example.seatchoice.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ValidErrorResponse {
+	private ErrorCode errorCode;
+	private String errorField;
+	private String errorMessage;
+
+	public static ResponseEntity<ValidErrorResponse> from(ErrorCode errorCode,
+		String errorField,
+		String errorMessage,
+		HttpStatus status) {
+		return ResponseEntity
+			.status(status)
+			.body(ValidErrorResponse.builder()
+				.errorCode(errorCode)
+				.errorField(errorField)
+				.errorMessage(errorMessage)
+				.build());
+	}
+}

--- a/src/main/java/com/example/seatchoice/entity/Review.java
+++ b/src/main/java/com/example/seatchoice/entity/Review.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor
@@ -33,4 +34,10 @@ public class Review extends BaseEntity {
 
 	@NotNull
 	private Integer rating;
+
+	@ColumnDefault("0")
+	private Long likeAmount;
+
+	@ColumnDefault("0")
+	private Long commentAmount;
 }

--- a/src/main/java/com/example/seatchoice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seatchoice/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.example.seatchoice.dto.common.ErrorResponse;
+import com.example.seatchoice.dto.validation.ValidErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,9 +24,10 @@ public class GlobalExceptionHandler {
 
 	// 발생되는 예외 예시, 밑으로 추가
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+	public ResponseEntity<ValidErrorResponse> handleMethodArgumentNotValidException(
 		MethodArgumentNotValidException e) {
-		return ErrorResponse.from(METHOD_ARGUMENT_NOT_VALID, BAD_REQUEST);
+		return ValidErrorResponse.from(METHOD_ARGUMENT_NOT_VALID, e.getFieldError().getField(),
+			e.getFieldError().getDefaultMessage(), BAD_REQUEST);
 	}
 
 	@ResponseStatus(INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/example/seatchoice/repository/CommentRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/CommentRepository.java
@@ -1,11 +1,10 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.Comment;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-	List<Comment> findAllByReviewId(Long id);
+
 }

--- a/src/main/java/com/example/seatchoice/repository/CommentRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.example.seatchoice.repository;
+
+import com.example.seatchoice.entity.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+	List<Comment> findAllByReviewId(Long id);
+}

--- a/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
@@ -1,9 +1,8 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.ReviewLike;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
-	List<ReviewLike> findAllByReviewId(Long id);
+
 }

--- a/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.Review;
+import com.example.seatchoice.repository.reviewPaging.ReviewRepositoryCustom;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 	List<Review> findAllByTheaterSeatId(Long id);
 
 	@Modifying

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.seatchoice.repository.reviewPaging;
+
+import com.example.seatchoice.dto.cond.ReviewInfoCond;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ReviewRepositoryCustom {
+	Slice<ReviewInfoCond> searchBySlice(Long lastReviewId, Pageable pageable);
+}

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.example.seatchoice.repository.reviewPaging;
+
+import static com.example.seatchoice.entity.QReview.review;
+
+import com.example.seatchoice.dto.cond.ReviewInfoCond;
+import com.example.seatchoice.entity.Review;
+import com.example.seatchoice.exception.CustomException;
+import com.example.seatchoice.type.ErrorCode;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<ReviewInfoCond> searchBySlice(Long lastReviewId,
+		Pageable pageable) {
+		List<Review> reviews = queryFactory
+			.selectFrom(review)
+			.where(ltReviewId(lastReviewId)) // review.id < lastReviewId
+			.orderBy(review.id.desc()) // 최신순으로 보여줌
+			.limit(pageable.getPageSize() + 1) // limit보다 한 개 더 들고온다.
+			.fetch();
+
+		if (reviews.size() == 0) {
+			throw new CustomException(ErrorCode.NO_REVIEW_DATA,
+				HttpStatus.BAD_REQUEST);
+		}
+		List<ReviewInfoCond> reviewInfoConds = new ArrayList<>(ReviewInfoCond.of(reviews));
+		return checkLastPage(pageable, reviewInfoConds);
+	}
+
+	// 동적 쿼리를 위한 BooleanExpression
+	private BooleanExpression ltReviewId(Long reviewId) {
+		if (reviewId == null) {
+			return null;
+		}
+		return review.id.lt(reviewId);
+	}
+
+	private Slice<ReviewInfoCond> checkLastPage(Pageable pageable, List<ReviewInfoCond> results) {
+		boolean hasNext = false;
+		// 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+		if (results.size() > pageable.getPageSize()) {
+			hasNext = true;
+			results.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(results, pageable, hasNext);
+	}
+}

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -4,15 +4,11 @@ import com.example.seatchoice.dto.cond.ReviewCond;
 import com.example.seatchoice.dto.cond.ReviewDetailCond;
 import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.param.ReviewParam;
-import com.example.seatchoice.entity.Comment;
 import com.example.seatchoice.entity.Image;
 import com.example.seatchoice.entity.Review;
-import com.example.seatchoice.entity.ReviewLike;
 import com.example.seatchoice.entity.TheaterSeat;
 import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.repository.CommentRepository;
 import com.example.seatchoice.repository.ImageRepository;
-import com.example.seatchoice.repository.ReviewLikeRepository;
 import com.example.seatchoice.repository.ReviewRepository;
 import com.example.seatchoice.repository.TheaterSeatRepository;
 import com.example.seatchoice.type.ErrorCode;
@@ -37,8 +33,6 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final ImageRepository imageRepository;
 	private final TheaterSeatRepository theaterSeatRepository;
-	private final ReviewLikeRepository reviewLikeRepository;
-	private final CommentRepository commentRepository;
 	private final ImageService s3Service;
 
 
@@ -100,8 +94,7 @@ public class ReviewService {
 
 		List<Review> reviews = reviewRepository.findAllByTheaterSeatId(review.getTheaterSeat().getId());
 
-		return ReviewDetailCond.from(review, getReviewRating(reviews),
-			getLikeAmount(reviewId), images);
+		return ReviewDetailCond.from(review, getReviewRating(reviews), images);
 	}
 
 	// 리뷰 목록 조회
@@ -120,8 +113,6 @@ public class ReviewService {
 
 		for (ReviewInfoCond reviewInfoCond : reviewInfoConds) {
 			reviewInfoCond.setRating(rating);
-			reviewInfoCond.setLikeAmount(getLikeAmount(reviewInfoCond.getReviewId()));
-			reviewInfoCond.setCommentAmount(getCommentAmount(reviewInfoCond.getReviewId()));
 		}
 
 		return reviewInfoConds;
@@ -138,7 +129,6 @@ public class ReviewService {
 		reviewRepository.deleteReviewLikeById(reviewId);
 		reviewRepository.delete(review);
 	}
-
 
 	// 리뷰 등록 시 등록한 좌석 정보로 해당 공연장 좌석 받아오기
 	public TheaterSeat getTheaterSeat(List<TheaterSeat> theaterSeats, ReviewParam request) {
@@ -167,18 +157,5 @@ public class ReviewService {
 			total += reviews.get(i).getRating();
 		}
 		return Math.round((total / reviews.size()) * 10) / 10.0;
-	}
-
-	// 좌석 좋아요 개수
-	public Integer getLikeAmount(Long reviewId) {
-		List<ReviewLike> reviewLikes = reviewLikeRepository.findAllByReviewId(reviewId);
-		if (CollectionUtils.isEmpty(reviewLikes)) return 0;
-		return reviewLikes.size();
-	}
-
-	public Integer getCommentAmount(Long reviewId) {
-		List<Comment> comments = commentRepository.findAllByReviewId(reviewId);
-		if (CollectionUtils.isEmpty(comments)) return 0;
-		return comments.size();
 	}
 }

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -19,6 +19,7 @@ import com.example.seatchoice.type.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ReviewService {
 
 	private final ReviewRepository reviewRepository;
@@ -43,6 +45,9 @@ public class ReviewService {
 	// 리뷰 등록
 	public ReviewCond createReview(Long theaterId, List<MultipartFile> files, ReviewParam request) {
 		// TODO 로그인 된 유저 검증
+
+		// 별점 표시 안 할 경우 0점으로 처리
+		if (request.getRating() == null) request.setRating(0);
 
 		List<TheaterSeat> theaterSeats = theaterSeatRepository.findAllByTheaterId(theaterId);
 		TheaterSeat theaterSeat = getTheaterSeat(theaterSeats, request);

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 	NOT_FOUND_REVIEW("해당 리뷰가 존재하지 않습니다."),
 	IMAGE_UPLOAD_FAIL("이미지 업로드에 실패했습니다."),
 	WRONG_FILE_FORM("잘못된 형식의 파일입니다."),
-	ERROR_CODE_500("서버 에러. 문의가 필요합니다.")
+	ERROR_CODE_500("서버 에러. 문의가 필요합니다."),
+	NO_REVIEW_DATA("더이상 조회할 리뷰가 없습니다.")
 	;
 
 	private final String message;


### PR DESCRIPTION
### 변경사항
service getReviews에서 리뷰 하나 당 좋아요 개수와 댓글 개수를 for문 돌려 가지고 오는데
쿼리를 많이 발생해 비효율적인 거 같습니다. 저는 review entity에 댓글 개수와 좋아요 개수를 추가해
댓글 작성/취소 및 좋아요 생성/취소 시에 개수를 변경하는 게 어떨까 합니다.
좋은 의견 있으시면 코멘트 주세요! 

**AS-IS**
- 리뷰 목록 조회 구현
- 무한스크롤 적용
- no offset + querydsl + slice 적용해서 무한스크롤 적용했습니다!
- Q-Class 생성
- 무한스크롤 시, 더이상 조회할 리뷰가 없을 때를 위한 errorcode 추가(NO_DATA_REVIEW)

**TO-BE**
- validation custom exception 구현
- 좋아요 개수와 댓글 개수 가져오는 로직 고민

### 테스트 
- [ ] 테스트 코드
- [x] API 테스트 

- reviw entity에 좋아요 개수와 댓글 개수 컬럼 추가 후 쿼리 변화
![스크린샷 2023-02-13 오전 12 18 57](https://user-images.githubusercontent.com/68212526/218320025-e96d24c9-b8d5-4af9-8b1a-3f87f9734cfa.png)

