### PR TITLE
feat : 리뷰 수정 구현

### DIFF
--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -4,6 +4,8 @@ import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.dto.cond.ReviewCond;
 import com.example.seatchoice.dto.cond.ReviewDetailCond;
 import com.example.seatchoice.dto.cond.ReviewInfoCond;
+import com.example.seatchoice.dto.cond.ReviewModifyCond;
+import com.example.seatchoice.dto.param.ReviewModifyParam;
 import com.example.seatchoice.dto.param.ReviewParam;
 import com.example.seatchoice.service.ReviewService;
 import java.util.List;
@@ -41,8 +43,7 @@ public class ReviewController {
 
 		// image file을 선택하지 않았을 때
 		if (files.get(0).getSize() == 0) files = null;
-		ReviewCond reviewCond = reviewService.createReview(theaterId, files, request);
-		return new ApiResponse<>(reviewCond);
+		return new ApiResponse<>(reviewService.createReview(theaterId, files, request));
 	}
 
 	// 리뷰 상세보기
@@ -57,6 +58,19 @@ public class ReviewController {
 		@RequestParam(required = false) Long lastReviewId,
 		@RequestParam Long seatId, Pageable pageable) {
 		return new ApiResponse<>(reviewService.getReviews(lastReviewId, seatId, pageable));
+	}
+
+	// 리뷰 수정
+	@PostMapping("/reviews/{reviewId}")
+	public ApiResponse<ReviewModifyCond> createReview(
+		@PathVariable Long reviewId,
+		@RequestPart(value = "image", required = false) List<MultipartFile> files,
+		@Valid @RequestPart(value = "data", required = false) ReviewModifyParam request,
+		@RequestParam(value = "deleteImages", required = false) List<String> deleteImages) {
+
+		// image file을 선택하지 않았을 때
+		if (files.get(0).getSize() == 0) files = null;
+		return new ApiResponse<>(reviewService.updateReview(reviewId, files, request, deleteImages));
 	}
 
 	// 리뷰 삭제

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewModifyCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewModifyCond.java
@@ -1,0 +1,59 @@
+package com.example.seatchoice.dto.cond;
+
+import com.example.seatchoice.entity.Image;
+import com.example.seatchoice.entity.Review;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.CollectionUtils;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewModifyCond {
+	private Long userId;
+	private String nickname;
+	private LocalDateTime createdAt;
+	private Integer floor;
+	private String section;
+	private String row;
+	private Integer seatNumber;
+	private Double rating; // 평점
+	private Long likeAmount; // 좋아요 개수
+	private String content;
+	private List<String> images;
+
+
+	public static ReviewModifyCond from(Review review, Double rating, List<Image> images) {
+		return ReviewModifyCond.builder()
+			.userId(review.getMember().getId())
+			.nickname(review.getMember().getNickname())
+			.createdAt(review.getMember().getCreatedAt())
+			.floor(review.getTheaterSeat().getFloor())
+			.section(review.getTheaterSeat().getSection())
+			.row(review.getTheaterSeat().getSeatRow())
+			.seatNumber(review.getTheaterSeat().getNumber())
+			.rating(rating)
+			.likeAmount(review.getLikeAmount())
+			.content(review.getContent())
+			.images(getImages(images))
+			.build();
+	}
+
+	public static List<String> getImages(List<Image> images) {
+		if (CollectionUtils.isEmpty(images)) {
+			return null;
+		}
+
+		List<String> list = new ArrayList<>();
+		for (Image img : images) {
+			list.add(img.getUrl());
+		}
+		return list;
+	}
+}

--- a/src/main/java/com/example/seatchoice/dto/param/ReviewModifyParam.java
+++ b/src/main/java/com/example/seatchoice/dto/param/ReviewModifyParam.java
@@ -1,0 +1,20 @@
+package com.example.seatchoice.dto.param;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewModifyParam {
+	@NotBlank(message = "필수 입력입니다.")
+	@Pattern(regexp = "^.{1,300}$", message = "리뷰내용은 1~300자로 내로 입력하세요.")
+	private String content;
+
+	private Integer rating;
+}

--- a/src/main/java/com/example/seatchoice/dto/validation/ValidErrorResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/validation/ValidErrorResponse.java
@@ -1,12 +1,9 @@
 package com.example.seatchoice.dto.validation;
 
-import com.example.seatchoice.dto.common.ErrorResponse;
 import com.example.seatchoice.type.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/src/main/java/com/example/seatchoice/entity/Review.java
+++ b/src/main/java/com/example/seatchoice/entity/Review.java
@@ -10,9 +10,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/example/seatchoice/repository/ImageRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ImageRepository.java
@@ -4,8 +4,11 @@ import com.example.seatchoice.entity.Image;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findAllByReviewId(Long id);
+	@Transactional
+	void deleteByUrl(String url);
 }

--- a/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
@@ -14,13 +15,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
 	@Modifying
 	@Query("delete from Comment c where c.review.id =:id ")
+	@Transactional
 	void deleteCommentById(Long id);
 
 	@Modifying
 	@Query("delete from ReviewLike rl where rl.review.id =:id ")
+	@Transactional
 	void deleteReviewLikeById(Long id);
 
 	@Modifying
 	@Query("delete from Image im where im.review.id =:id ")
+	@Transactional
 	void deleteImageById(Long id);
 }

--- a/src/main/java/com/example/seatchoice/service/ImageService.java
+++ b/src/main/java/com/example/seatchoice/service/ImageService.java
@@ -2,6 +2,7 @@ package com.example.seatchoice.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.seatchoice.exception.CustomException;
@@ -51,6 +52,15 @@ public class ImageService {
 
 		return fileUrlList;
 	}
+
+	public void deleteImage(List<String> images) {
+		String fileName = "";
+		for (String url : images) {
+			fileName = url.split("/")[3];
+		}
+		amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+	}
+
 
 	private String createFileName(String fileName) {
 		return UUID.randomUUID().toString().concat(getFileExtension(fileName));


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 리뷰 수정 구현
- 리뷰 수정은 좌석에 대한 comment, rating 만 바꿀 수 있도록 했습니다.
  - 좌석을 잘못 입력 했을 경우, 리뷰 삭제 후 다시 작성하도록 FE쪽과 상의했습니다!
  - 좌석도 수정할 수 있게 되면, user들은 해당 좌석에 대한 리뷰에 대해 댓글과 좋아요를 남긴 것이기 때문에
  좋아요와 댓글을 모두 삭제해야 되는 문제점이 발생합니다! 그래서 좌석 수정은 불가하도록 했습니다!

**TO-BE**
- 리뷰가 있는 좌석 목록 조회 구현
- 좋아요 생성 및 취소 구현
- user 검증 

### 테스트 
- [ ] 테스트 코드
- [x] API 테스트 
