### PR TITLE
feat : 리뷰가 있는 좌석 조회 구현

### DIFF
--- a/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
+++ b/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
@@ -1,0 +1,22 @@
+package com.example.seatchoice.controller;
+
+import com.example.seatchoice.dto.common.ApiResponse;
+import com.example.seatchoice.service.TheaterSeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TheaterSeatController {
+
+	private final TheaterSeatService theaterSeatService;
+
+	@GetMapping("/theaters/{theaterId}/seats")
+	public ApiResponse<?> getSeatsWithReviews(@PathVariable Long theaterId) {
+		return new ApiResponse<>(theaterSeatService.getSeatsWithReviews(theaterId));
+	}
+}

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
@@ -20,13 +20,13 @@ public class ReviewDetailCond {
 	private String section;
 	private String row;
 	private Integer seatNumber;
-	private Double rating; // 평점
+	private Integer rating; // 평점
 	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private List<String> images;
 
 
-	public static ReviewDetailCond from(Review review, Double rating, List<String> images) {
+	public static ReviewDetailCond from(Review review, List<String> images) {
 		return ReviewDetailCond.builder()
 			.userId(review.getMember().getId())
 			.nickname(review.getMember().getNickname())
@@ -35,7 +35,7 @@ public class ReviewDetailCond {
 			.section(review.getTheaterSeat().getSection())
 			.row(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
-			.rating(rating)
+			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.images(images)

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -37,7 +37,7 @@ public class ReviewInfoCond {
 			.floor(review.getTheaterSeat().getFloor())
 			.section(review.getTheaterSeat().getSection())
 			.row(review.getTheaterSeat().getSeatRow())
-			.seatNumber(review.getTheaterSeat().getNumber()) // 바꾼 부분
+			.seatNumber(review.getTheaterSeat().getNumber())
 			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -16,13 +16,14 @@ import org.springframework.util.CollectionUtils;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewInfoCond {
+	private Double seatRating; // 좌석 평점
 	private Long reviewId;
 	private Long userId;
 	private Integer floor;
 	private String section;
 	private String row;
 	private Integer seatNumber;
-	private Double rating; // 평점
+	private Integer rating; // 개인 평점
 	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private String thumbnail;
@@ -30,13 +31,14 @@ public class ReviewInfoCond {
 
 	public static ReviewInfoCond from(Review review) {
 		return ReviewInfoCond.builder()
+			.seatRating(review.getTheaterSeat().getRating())
 			.reviewId(review.getId())
 			.userId(review.getMember().getId())
 			.floor(review.getTheaterSeat().getFloor())
 			.section(review.getTheaterSeat().getSection())
 			.row(review.getTheaterSeat().getSeatRow())
-			.seatNumber(review.getTheaterSeat().getNumber())
-			.rating(null)
+			.seatNumber(review.getTheaterSeat().getNumber()) // 바꾼 부분
+			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.thumbnail(review.getThumbnailUrl())

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewModifyCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewModifyCond.java
@@ -23,13 +23,13 @@ public class ReviewModifyCond {
 	private String section;
 	private String row;
 	private Integer seatNumber;
-	private Double rating; // 평점
+	private Integer rating; // 평점
 	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private List<String> images;
 
 
-	public static ReviewModifyCond from(Review review, Double rating, List<Image> images) {
+	public static ReviewModifyCond from(Review review, List<Image> images) {
 		return ReviewModifyCond.builder()
 			.userId(review.getMember().getId())
 			.nickname(review.getMember().getNickname())
@@ -38,7 +38,7 @@ public class ReviewModifyCond {
 			.section(review.getTheaterSeat().getSection())
 			.row(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
-			.rating(rating)
+			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.images(getImages(images))

--- a/src/main/java/com/example/seatchoice/dto/cond/TheaterSeatCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/TheaterSeatCond.java
@@ -1,0 +1,35 @@
+package com.example.seatchoice.dto.cond;
+
+import com.example.seatchoice.entity.TheaterSeat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterSeatCond {
+	private Long seatId;
+	private Integer floor;
+	private String section;
+	private String seatRow;
+	private Integer seatNumber;
+	private Long reviewAmount;
+	private Double rating; // 평점
+
+	public static TheaterSeatCond from(TheaterSeat seat) {
+		return TheaterSeatCond.builder()
+			.seatId(seat.getId())
+			.floor(seat.getFloor())
+			.section(seat.getSection())
+			.seatRow(seat.getSeatRow())
+			.seatNumber(seat.getNumber())
+			.reviewAmount(seat.getReviewAmount())
+			.rating(seat.getRating())
+			.build();
+	}
+}

--- a/src/main/java/com/example/seatchoice/entity/TheaterSeat.java
+++ b/src/main/java/com/example/seatchoice/entity/TheaterSeat.java
@@ -10,8 +10,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -32,4 +35,10 @@ public class TheaterSeat extends BaseEntity {
 
 	@NotNull
 	private Integer number;
+
+	@ColumnDefault("0")
+	private Long reviewAmount;
+
+	@ColumnDefault("0.0")
+	private Double rating;
 }

--- a/src/main/java/com/example/seatchoice/service/ImageService.java
+++ b/src/main/java/com/example/seatchoice/service/ImageService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.seatchoice.entity.Image;
 import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.type.ErrorCode;
 import java.io.IOException;
@@ -59,6 +60,14 @@ public class ImageService {
 			fileName = url.split("/")[3];
 		}
 		amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+	}
+
+	public void deleteImageFromObject(List<Image> images) {
+		String fileName = "";
+		for (Image img: images) {
+			fileName = img.getUrl().split("/")[3];
+			amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+		}
 	}
 
 

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -180,6 +180,7 @@ public class ReviewService {
 				() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW, HttpStatus.BAD_REQUEST));
 		Integer rating = review.getRating();
 		TheaterSeat theaterSeat = review.getTheaterSeat();
+		List<Image> images = imageRepository.findAllByReviewId(reviewId);
 
 		reviewRepository.deleteCommentById(reviewId);
 		reviewRepository.deleteImageById(reviewId);
@@ -188,6 +189,11 @@ public class ReviewService {
 
 		// 좌석 평점 수정
 		saveSeatRating(theaterSeat, delete, rating, 0);
+
+		// s3에서 이미지 삭제
+		if (!CollectionUtils.isEmpty(images)) {
+			s3Service.deleteImageFromObject(images);
+		}
 	}
 
 	// 리뷰 등록 시 등록한 좌석 정보로 해당 공연장 좌석 받아오기

--- a/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
@@ -1,0 +1,33 @@
+package com.example.seatchoice.service;
+
+import com.example.seatchoice.dto.cond.TheaterSeatCond;
+import com.example.seatchoice.entity.TheaterSeat;
+import com.example.seatchoice.repository.TheaterSeatRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+@Service
+@RequiredArgsConstructor
+public class TheaterSeatService {
+
+	private final TheaterSeatRepository theaterSeatRepository;
+	public List<TheaterSeatCond> getSeatsWithReviews(Long theaterId) {
+		List<TheaterSeat> seats = theaterSeatRepository.findAllByTheaterId(theaterId);
+
+		List<TheaterSeatCond> theaterSeatConds = new ArrayList<>();
+		if (!CollectionUtils.isEmpty(seats)) {
+			for (TheaterSeat seat : seats) {
+				if (seat.getReviewAmount() > 0) {
+					theaterSeatConds.add(TheaterSeatCond.from(seat));
+				}
+			}
+		} else {
+			theaterSeatConds = null;
+		}
+
+		return theaterSeatConds;
+	}
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 리뷰가 있는 좌석 구현
- theaterSeat entity에 rating (좌석 평점) 과 reviewAmount(좌석에 대한 리뷰 개수) 추가
  - entity에 좌석평점 및 리뷰개수를 추가하지 않으면 리뷰가 있는 좌석 조회 시, 
     1. 공연장 id로 좌석 list를 받아오고
     2. 좌석 list를 for문으로 돌려 좌석 id로 각 좌석에 대한 리뷰 list를 받아오고
     3. 리뷰가 있는 좌석을 알기 위해 그 list의 size로 리뷰 개수를 받아야 하며
     4. 다시 for문으로 리뷰 평점을 이용해 좌석 평점을 계산해야 합니다
  - 바뀐 로직으로 리뷰가 있는 좌석 조회를 할 경우,
    1. 공연장 id로 좌석 list를 받아오고
    2. 좌석이 존재한다면 좌석 list를 for문으로 돌려 리뷰 개수가 있는 좌석을 theaterconds에 담아 response로 보냅니다.
    3. 좌석이 존재하지 않는다면 null을 반환합니다. 
  - entity에 컬럼 추가하면서 리뷰 등록, 수정, 삭제 로직 조금씩 바꼈습니다!  
  
**TO-BE**
- 좋아요 생성 및 취소
- user 검증 로직 고민

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
