### PR TITLE
feat : 좋아요 생성/취소 구현 및 로그인 필요한 api 정의

### DIFF
--- a/src/main/java/com/example/seatchoice/config/SecurityConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.seatchoice.service.oauth.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,10 +33,17 @@ public class SecurityConfig {
 			).permitAll()
 			// 유저 권한이 필요한 api 추가
 			.antMatchers(
-				"/test"
-			).hasRole("USER");
+				"/test",
+				"/api/likes/**",
+				"/api/theaters/**/reviews"
+			).hasRole("USER")
+			.antMatchers(HttpMethod.POST, "/api/reviews/**")
+			.hasRole("USER")
+			.antMatchers(HttpMethod.DELETE, "/api/reviews/**")
+			.hasRole("USER");
 
-		http.addFilterBefore(new JwtAuthenticationFilter(tokenService), UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(new JwtAuthenticationFilter(tokenService),
+			UsernamePasswordAuthenticationFilter.class);
 		http.exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint());
 
 		return http.build();

--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -71,7 +71,6 @@ public class ReviewController {
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
 		@Valid @RequestPart(value = "data", required = false) ReviewModifyParam request,
 		@RequestParam(value = "deleteImages", required = false) List<String> deleteImages) {
-
 		// image file을 선택하지 않았을 때
 		if (files.get(0).getSize() == 0) files = null;
 		return new ApiResponse<>(reviewService.updateReview(reviewId, files, request, deleteImages));

--- a/src/main/java/com/example/seatchoice/controller/ReviewLikeController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewLikeController.java
@@ -1,0 +1,38 @@
+package com.example.seatchoice.controller;
+
+import com.example.seatchoice.dto.common.ApiResponse;
+import com.example.seatchoice.service.ReviewLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/likes")
+public class ReviewLikeController {
+
+	private final ReviewLikeService reviewLikeService;
+
+	// 좋아요 생성
+	@PostMapping
+	public ApiResponse<Void> createLike(
+		@RequestParam Long reviewId, @AuthenticationPrincipal OAuth2User oAuth2User) {
+		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+		reviewLikeService.createLike(memberId, reviewId);
+		return new ApiResponse<>();
+	}
+
+	// 좋아요 취소
+	@DeleteMapping
+	public ApiResponse<Void> deleteLike(
+		@RequestParam Long reviewId, @AuthenticationPrincipal OAuth2User oAuth2User) {
+		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+		reviewLikeService.deleteLike(memberId, reviewId);
+		return new ApiResponse<>();
+	}
+}

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
@@ -24,9 +24,10 @@ public class ReviewDetailCond {
 	private Long likeAmount; // 좋아요 개수
 	private String content;
 	private List<String> images;
+	private Boolean likeChecked;
 
 
-	public static ReviewDetailCond from(Review review, List<String> images) {
+	public static ReviewDetailCond from(Review review, List<String> images, Boolean likeChecked) {
 		return ReviewDetailCond.builder()
 			.userId(review.getMember().getId())
 			.nickname(review.getMember().getNickname())
@@ -39,6 +40,7 @@ public class ReviewDetailCond {
 			.likeAmount(review.getLikeAmount())
 			.content(review.getContent())
 			.images(images)
+			.likeChecked(likeChecked)
 			.build();
 	}
 }

--- a/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewLikeRepository.java
@@ -1,8 +1,12 @@
 package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.ReviewLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
-
+	Optional<ReviewLike> findByMemberIdAndReviewId(Long memberId, Long reviewId);
+	boolean existsByMemberIdAndReviewId(Long memberId, Long reviewId);
 }

--- a/src/main/java/com/example/seatchoice/service/ReviewLikeService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewLikeService.java
@@ -1,0 +1,58 @@
+package com.example.seatchoice.service;
+
+import com.example.seatchoice.entity.Member;
+import com.example.seatchoice.entity.Review;
+import com.example.seatchoice.entity.ReviewLike;
+import com.example.seatchoice.exception.CustomException;
+import com.example.seatchoice.repository.MemberRepository;
+import com.example.seatchoice.repository.ReviewLikeRepository;
+import com.example.seatchoice.repository.ReviewRepository;
+import com.example.seatchoice.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewLikeService {
+
+	private final ReviewLikeRepository reviewLikeRepository;
+	private final ReviewRepository reviewRepository;
+	private final MemberRepository memberRepository;
+
+	public void createLike(Long memberId, Long reviewId) {
+		Member member = memberRepository.getReferenceById(memberId);
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW, HttpStatus.BAD_REQUEST));
+
+		if (reviewLikeRepository.existsByMemberIdAndReviewId(memberId, reviewId)) {
+			throw new CustomException(ErrorCode.DOUBLE_CHECKED_LIKE, HttpStatus.BAD_REQUEST);
+		}
+
+		reviewLikeRepository.save(ReviewLike.builder()
+			.member(member)
+			.review(review)
+			.build());
+
+		review.setLikeAmount(review.getLikeAmount() + 1);
+		reviewRepository.save(review);
+	}
+
+	public void deleteLike(Long memberId, Long reviewId) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW, HttpStatus.BAD_REQUEST));
+
+		ReviewLike reviewLike = reviewLikeRepository.findByMemberIdAndReviewId(memberId, reviewId)
+			.orElseThrow(
+				() -> new CustomException(ErrorCode.NOT_FOUND_LIKE, HttpStatus.BAD_REQUEST));
+
+		reviewLikeRepository.delete(reviewLike);
+
+		review.setLikeAmount(review.getLikeAmount() - 1 >= 0 ? review.getLikeAmount() - 1 : 0);
+		reviewRepository.save(review);
+	}
+}

--- a/src/main/java/com/example/seatchoice/service/ReviewLikeService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewLikeService.java
@@ -7,6 +7,7 @@ import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.repository.MemberRepository;
 import com.example.seatchoice.repository.ReviewLikeRepository;
 import com.example.seatchoice.repository.ReviewRepository;
+import com.example.seatchoice.type.AlarmType;
 import com.example.seatchoice.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,7 @@ public class ReviewLikeService {
 	private final ReviewLikeRepository reviewLikeRepository;
 	private final ReviewRepository reviewRepository;
 	private final MemberRepository memberRepository;
+	private final AlarmService alarmService;
 
 	public void createLike(Long memberId, Long reviewId) {
 		Member member = memberRepository.getReferenceById(memberId);
@@ -39,6 +41,10 @@ public class ReviewLikeService {
 
 		review.setLikeAmount(review.getLikeAmount() + 1);
 		reviewRepository.save(review);
+
+		// 알람 생성
+		String url = "https://seatchoice.site/api/reviews/" + reviewId;
+		alarmService.createAlarm(memberId, AlarmType.LIKE, url);
 	}
 
 	public void deleteLike(Long memberId, Long reviewId) {

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -23,11 +23,14 @@ public enum ErrorCode {
 	NOT_FOUND_ALARM("해당 알림이 존재하지 않습니다."),
 	NOT_FOUND_REVIEW("해당 리뷰가 존재하지 않습니다."),
 	NOT_FOUND_COMMENT("해당 댓글이 존재하지 않습니다."),
+	NOT_FOUND_LIKE("좋아요가 존재하지 않습니다."),
 	IMAGE_UPLOAD_FAIL("이미지 업로드에 실패했습니다."),
 	WRONG_FILE_FORM("잘못된 형식의 파일입니다."),
 	ERROR_CODE_500("서버 에러. 문의가 필요합니다."),
 	NOT_AUTHORITY_COMMENT("댓글을 수정하거나 삭제할 권한이 없습니다."),
-	NO_REVIEW_DATA("더이상 조회할 리뷰가 없습니다.")
+	NO_REVIEW_DATA("더이상 조회할 리뷰가 없습니다."),
+	DOUBLE_CHECKED_LIKE("이미 좋아요를 눌렀습니다."),
+	NO_AUTHORITY_LIKE("좋아요에 대한 권한이 없습니다. 로그인 하시기 바랍니다.")
 	;
 
 	private final String message;

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -30,7 +30,6 @@ public enum ErrorCode {
 	NOT_AUTHORITY_COMMENT("댓글을 수정하거나 삭제할 권한이 없습니다."),
 	NO_REVIEW_DATA("더이상 조회할 리뷰가 없습니다."),
 	DOUBLE_CHECKED_LIKE("이미 좋아요를 눌렀습니다."),
-	NO_AUTHORITY_LIKE("좋아요에 대한 권한이 없습니다. 로그인 하시기 바랍니다.")
 	;
 
 	private final String message;


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 좋아요 생성/취소 구현
- ReviewDetailCond에 likeChecked 변수 추가하여 리뷰 상세보기를 보고 있는 user가 좋아요를 눌렀는지 확인 가능
- securityconfig에 로그인 필요한 api 추가


**TO-BE**
- 로그인이 필요하지 않은 api 의 토큰 예외 처리 고민
- 테스트 코드 작성

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
