### PR TITLE
fix : 이미지 등록 및 수정 시 이미지 파일 넘어오지 않을 경우 null 처리 구현

### DIFF
--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -38,8 +38,6 @@ public class ReviewController {
 		@AuthenticationPrincipal OAuth2User oAuth2User,
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
 		@Valid @RequestPart("data") ReviewParam request) {
-		// image file을 선택하지 않았을 때
-		if (files.get(0).getSize() == 0) files = null;
 		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
 		return new ApiResponse<>(reviewService.createReview(memberId, theaterId, files, request));
 	}
@@ -69,10 +67,8 @@ public class ReviewController {
 	public ApiResponse<ReviewModifyCond> createReview(
 		@PathVariable Long reviewId,
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
-		@Valid @RequestPart(value = "data", required = false) ReviewModifyParam request,
+		@Valid @RequestPart(value = "data") ReviewModifyParam request,
 		@RequestParam(value = "deleteImages", required = false) List<String> deleteImages) {
-		// image file을 선택하지 않았을 때
-		if (files.get(0).getSize() == 0) files = null;
 		return new ApiResponse<>(reviewService.updateReview(reviewId, files, request, deleteImages));
 	}
 

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -48,6 +48,9 @@ public class ReviewService {
 	// 리뷰 등록
 	public ReviewCond createReview(Long memberId, Long theaterId, List<MultipartFile> files,
 		ReviewParam request) {
+		// image file을 선택하지 않았을 때
+		if (CollectionUtils.isEmpty(files) || files.get(0).getSize() == 0) files = null;
+
 		// 별점 표시 안 할 경우 0점으로 처리
 		if (request.getRating() == null) request.setRating(0);
 
@@ -131,6 +134,9 @@ public class ReviewService {
 			.orElseThrow(
 				() -> new CustomException(ErrorCode.NOT_FOUND_REVIEW, HttpStatus.BAD_REQUEST));
 		Integer oldReviewRating = review.getRating();
+
+		// image file을 선택하지 않았을 때
+		if (CollectionUtils.isEmpty(files) || files.get(0).getSize() == 0) files = null;
 
 		// 별점 표시 안 할 경우 0점으로 처리
 		if (request.getRating() == null) request.setRating(0);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 리뷰 이미지 등록 및 수정 시 프론트 쪽에서 이미지 파일 넘어오지 않을 경우 null 처리 
- 기존 이미지 파일 null 처리 controller -> service로 코드 옮겼습니다.

**TO-BE**
- 테스트 코드 작성

### 테스트 

- [ ] 테스트 코드
- [x] API 테스트 
