### PR TITLE
feat : access_token 재발급 재구현

### DIFF
--- a/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
@@ -1,14 +1,13 @@
 package com.example.seatchoice.config;
 
 import static com.example.seatchoice.type.ErrorCode.EMPTY_TOKEN;
-import static com.example.seatchoice.type.ErrorCode.EXPIRED_TOKEN;
 import static com.example.seatchoice.type.ErrorCode.INVALID_TOKEN;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import com.example.seatchoice.dto.auth.Token.AccessToken;
 import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.service.oauth.TokenService;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
 import java.io.IOException;
@@ -17,6 +16,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -33,8 +33,14 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 		try {
 			String token = tokenService.resolveToken((HttpServletRequest) request);
 
-			if (tokenService.validateToken(token)) {
+			if (tokenService.validateToken(token)) { // access_token 유효할 때
 				Authentication authentication = tokenService.getAuthentication(token);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} else { // access_token 유효하지 않을 때 재발급
+				AccessToken accessToken = tokenService.reissueAccessToken((HttpServletRequest) request, (HttpServletResponse) response);
+				System.out.println(accessToken.getAccessToken());
+				((HttpServletResponse) response).setHeader("Authorization", accessToken.toString());
+				Authentication authentication = tokenService.getAuthentication(accessToken.getAccessToken());
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
 
@@ -43,9 +49,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 				request.setAttribute("httpStatus", e.getHttpStatus());
 		} catch (SignatureException | MalformedJwtException e) {
 			request.setAttribute("errorCode", INVALID_TOKEN);
-			request.setAttribute("httpStatus", UNAUTHORIZED);
-		} catch (ExpiredJwtException e) {
-			request.setAttribute("errorCode", EXPIRED_TOKEN);
 			request.setAttribute("httpStatus", UNAUTHORIZED);
 		} catch (IllegalArgumentException e) {
 			request.setAttribute("errorCode", EMPTY_TOKEN);

--- a/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
@@ -5,7 +5,6 @@ import static com.example.seatchoice.type.ErrorCode.INVALID_TOKEN;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
-import com.example.seatchoice.dto.auth.Token.AccessToken;
 import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.service.oauth.TokenService;
 import io.jsonwebtoken.MalformedJwtException;
@@ -37,10 +36,10 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 				Authentication authentication = tokenService.getAuthentication(token);
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			} else { // access_token 유효하지 않을 때 재발급
-				AccessToken accessToken = tokenService.reissueAccessToken((HttpServletRequest) request, (HttpServletResponse) response);
-				System.out.println(accessToken.getAccessToken());
-				((HttpServletResponse) response).setHeader("Authorization", accessToken.toString());
-				Authentication authentication = tokenService.getAuthentication(accessToken.getAccessToken());
+				String accessToken =
+					tokenService.reissueAccessToken((HttpServletRequest) request, (HttpServletResponse) response);
+				((HttpServletResponse) response).setHeader("Authorization", accessToken);
+				Authentication authentication = tokenService.getAuthentication(accessToken);
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
 

--- a/src/main/java/com/example/seatchoice/config/SecurityConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
 			).permitAll()
 			// 유저 권한이 필요한 api 추가
 			.antMatchers(
-				"/test",
 				"/api/likes/**",
 				"/api/theaters/**/reviews"
 			).hasRole("USER")

--- a/src/main/java/com/example/seatchoice/controller/ChatController.java
+++ b/src/main/java/com/example/seatchoice/controller/ChatController.java
@@ -2,13 +2,13 @@ package com.example.seatchoice.controller;
 
 import com.example.seatchoice.config.kafka.KafkaSender;
 import com.example.seatchoice.dto.param.ChattingMessageParam;
-import com.example.seatchoice.service.oauth.TokenService;
+import com.example.seatchoice.entity.Member;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,13 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final KafkaSender kafkaSender;
-    private final TokenService tokenService;
     private static String KAFKA_TOPIC = "kafka-chatting"; // kafka 내부 topic
 
     // "/api/send/{roomId}"로 들어오는 메시지를 "/api/chat/{roomId}"을 구독하고있는 사람들에게 송신
     @MessageMapping("/{roomId}")
     public void sendMessage(@DestinationVariable Long roomId,
-                            @Header("Authorization") String token,
+                            @AuthenticationPrincipal Member member,
                             ChattingMessageParam message) {
 
         // 현재 시간
@@ -32,7 +31,7 @@ public class ChatController {
             .format(LocalDateTime.now());
 
         message.setRoomId(roomId);
-        message.setNickname(tokenService.getNickname(token).toString());
+        message.setNickname(member.getNickname());
         message.setTimeStamp(sendTime);
 
         kafkaSender.send(KAFKA_TOPIC, message);

--- a/src/main/java/com/example/seatchoice/controller/CommentController.java
+++ b/src/main/java/com/example/seatchoice/controller/CommentController.java
@@ -3,12 +3,12 @@ package com.example.seatchoice.controller;
 import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.dto.cond.CommentCond;
 import com.example.seatchoice.dto.param.CommentParam;
+import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.service.CommentService;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,10 +26,9 @@ public class CommentController {
 
 	@GetMapping("/comment")
 	public ApiResponse<Void> create(@RequestBody @Valid CommentParam.Create commentParam,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+		@AuthenticationPrincipal Member member) {
 
-		commentService.create(memberId, commentParam);
+		commentService.create(member.getId(), commentParam);
 
 		return new ApiResponse<>();
 	}
@@ -37,21 +36,18 @@ public class CommentController {
 	@PutMapping("/comment/{commentId}")
 	public ApiResponse<Void> modify(@PathVariable Long commentId,
 		@RequestBody @Valid CommentParam.Modify commentParam,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
+		@AuthenticationPrincipal Member member) {
 
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
-
-		commentService.modify(memberId, commentId, commentParam);
+		commentService.modify(member.getId(), commentId, commentParam);
 
 		return new ApiResponse<>();
 	}
 
 	@DeleteMapping("/comment/{commentId}")
 	public ApiResponse<Void> delete(@PathVariable Long commentId,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+		@AuthenticationPrincipal Member member) {
 
-		commentService.delete(memberId, commentId);
+		commentService.delete(member.getId(), commentId);
 
 		return new ApiResponse<>();
 	}

--- a/src/main/java/com/example/seatchoice/controller/MemberController.java
+++ b/src/main/java/com/example/seatchoice/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.example.seatchoice.controller;
 
 import com.example.seatchoice.dto.auth.Token;
-import com.example.seatchoice.dto.auth.Token.AccessToken;
 import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.service.MemberService;
 import java.io.IOException;
@@ -28,9 +27,8 @@ public class MemberController {
 		throws IOException, ParseException {
 
 		Token token = memberService.oauthLogin(code, provider);
-		AccessToken accessToken = new AccessToken(token.getAccessToken());
+		response.setHeader("Authorization", token.getAccessToken());
 
-		response.setHeader("Authorization", accessToken.getAccessToken());
 		Cookie cookie = new Cookie(REFRESH_TOKEN_KEY, token.getRefreshToken());
 		cookie.setHttpOnly(true);
 		cookie.setPath("/");

--- a/src/main/java/com/example/seatchoice/controller/MemberController.java
+++ b/src/main/java/com/example/seatchoice/controller/MemberController.java
@@ -1,59 +1,41 @@
 package com.example.seatchoice.controller;
 
-import static org.springframework.http.HttpStatus.OK;
-
 import com.example.seatchoice.dto.auth.Token;
 import com.example.seatchoice.dto.auth.Token.AccessToken;
 import com.example.seatchoice.dto.common.ApiResponse;
 import com.example.seatchoice.service.MemberService;
-import com.example.seatchoice.service.oauth.TokenService;
 import java.io.IOException;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
 
-	private final TokenService tokenService;
 	private final MemberService memberService;
-	private final RedisTemplate<Long, Object> redisTemplate;
 
 	private final String REFRESH_TOKEN_KEY = "refreshToken";
 
 	@PostMapping("/api/oauth/{provider}/login")
-	public ApiResponse<AccessToken> oauthLogin(
+	public ApiResponse oauthLogin(
 		@RequestParam String code, @PathVariable("provider") String provider, HttpServletResponse response)
 		throws IOException, ParseException {
 
 		Token token = memberService.oauthLogin(code, provider);
 		AccessToken accessToken = new AccessToken(token.getAccessToken());
 
+		response.setHeader("Authorization", accessToken.getAccessToken());
 		Cookie cookie = new Cookie(REFRESH_TOKEN_KEY, token.getRefreshToken());
 		cookie.setHttpOnly(true);
 		cookie.setPath("/");
 		response.addCookie(cookie);
 
-		return new ApiResponse(accessToken);
-	}
-
-	@GetMapping("/api/reissue/refresh-token")
-	@ResponseStatus(OK)
-	public ApiResponse<AccessToken> reissueAccessToken(
-		HttpServletRequest request, @CookieValue String refreshToken) {
-		AccessToken accessToken = tokenService.reissueAccessToken(request, refreshToken);
-
-		return new ApiResponse(accessToken);
+		return new ApiResponse();
 	}
 }

--- a/src/main/java/com/example/seatchoice/controller/ReviewController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.dto.cond.ReviewModifyCond;
 import com.example.seatchoice.dto.param.ReviewModifyParam;
 import com.example.seatchoice.dto.param.ReviewParam;
+import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.service.ReviewService;
 import java.util.List;
 import javax.validation.Valid;
@@ -14,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,20 +35,20 @@ public class ReviewController {
 	@PostMapping("/theaters/{theaterId}/reviews")
 	public ApiResponse<ReviewCond> createReview(
 		@PathVariable Long theaterId,
-		@AuthenticationPrincipal OAuth2User oAuth2User,
+		@AuthenticationPrincipal Member member,
 		@RequestPart(value = "image", required = false) List<MultipartFile> files,
 		@Valid @RequestPart("data") ReviewParam request) {
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
-		return new ApiResponse<>(reviewService.createReview(memberId, theaterId, files, request));
+
+		return new ApiResponse<>(reviewService.createReview(member.getId(), theaterId, files, request));
 	}
 
 	// 리뷰 상세보기
 	@GetMapping("/reviews/{reviewId}")
 	public ApiResponse<ReviewDetailCond> getReview(@PathVariable Long reviewId,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
+		@AuthenticationPrincipal Member member) {
 		Long memberId = null;
-		if (oAuth2User != null) {
-			memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+		if (member != null) {
+			memberId = member.getId();
 		}
 
 		return new ApiResponse<>(reviewService.getReview(memberId, reviewId));

--- a/src/main/java/com/example/seatchoice/controller/ReviewLikeController.java
+++ b/src/main/java/com/example/seatchoice/controller/ReviewLikeController.java
@@ -1,10 +1,10 @@
 package com.example.seatchoice.controller;
 
 import com.example.seatchoice.dto.common.ApiResponse;
+import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.service.ReviewLikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,18 +21,18 @@ public class ReviewLikeController {
 	// 좋아요 생성
 	@PostMapping
 	public ApiResponse<Void> createLike(
-		@RequestParam Long reviewId, @AuthenticationPrincipal OAuth2User oAuth2User) {
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
-		reviewLikeService.createLike(memberId, reviewId);
+		@RequestParam Long reviewId, @AuthenticationPrincipal Member member) {
+
+		reviewLikeService.createLike(member.getId(), reviewId);
 		return new ApiResponse<>();
 	}
 
 	// 좋아요 취소
 	@DeleteMapping
 	public ApiResponse<Void> deleteLike(
-		@RequestParam Long reviewId, @AuthenticationPrincipal OAuth2User oAuth2User) {
-		Long memberId = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
-		reviewLikeService.deleteLike(memberId, reviewId);
+		@RequestParam Long reviewId, @AuthenticationPrincipal Member member) {
+
+		reviewLikeService.deleteLike(member.getId(), reviewId);
 		return new ApiResponse<>();
 	}
 }

--- a/src/main/java/com/example/seatchoice/dto/auth/Token.java
+++ b/src/main/java/com/example/seatchoice/dto/auth/Token.java
@@ -9,10 +9,4 @@ public class Token {
 
 	private String accessToken;
 	private String refreshToken;
-
-	@Getter
-	@AllArgsConstructor
-	public static class AccessToken {
-		private String accessToken;
-	}
 }

--- a/src/main/java/com/example/seatchoice/service/oauth/TokenService.java
+++ b/src/main/java/com/example/seatchoice/service/oauth/TokenService.java
@@ -8,7 +8,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
-import com.example.seatchoice.dto.auth.Token.AccessToken;
 import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.repository.MemberRepository;
@@ -123,7 +122,7 @@ public class TokenService{
 		}
 	}
 
-	public AccessToken reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+	public String reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 		try {
 			String refreshToken = getRefreshToken(request);
 			Long memberId = getMemberIdFromRefreshToken(refreshToken);
@@ -137,9 +136,7 @@ public class TokenService{
 				throw new CustomException(EXPIRED_REFRESH_TOKEN, UNAUTHORIZED);
 			}
 
-			String accessToken = createToken(member);
-
-			return new AccessToken(accessToken);
+			return createToken(member);
 
 		} catch (NullPointerException e) {
 			resetHeader(response);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인 시 body가 아닌 header에 access_token을 넣어 전달하는 것으로 변경했습니다.
- access_token 재발급 api를 삭제했습니다.  access_token이 만료 시 서버측에서 재발급을 처리합니다.
    - refresh_token만료 시 에러메세지를 반환합니다.

- Authentication principal 에 Member 객체를 저장할 수 있게 로직을 바꿨습니다.(기존엔 OAuth2User)

```java
public Authentication getAuthentication(String token) {
        Long memberId = getMemberId(token);
        
        Member member = memberRepository.findById(memberId).orElseThrow(
	        () -> new CustomException(NOT_FOUND_MEMBER, NOT_FOUND));
        
        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
        grantedAuthorities.add(new SimpleGrantedAuthority(member.getRole().name()));
        
        return new UsernamePasswordAuthenticationToken(member, "", grantedAuthorities);
}


// JwtAuthenticationFilter.java - jwt 토큰 인증 후 멤버 정보 저장 로직
Authentication authentication = tokenService.getAuthentication(token);
SecurityContextHolder.getContext().setAuthentication(authentication);

```

<br>

- (변경 전) controller에서 로그인한 멤버 정보를 가져올 때
```java
@GetMapping("/")
public String test(@AuthenticationPrincipal OAuth2User oAuth2User) {
        Long id = Long.valueOf(oAuth2User.getAttributes().get("id").toString());
        String nickname = oAuth2User.getAttributes().get("nickname").toString();
        
        return "성공";
}
```

- (변경 후) 더 간단하게 가져올 수 있습니다.
```java
@GetMapping("/")
public String test(@AuthenticationPrincipal Member member) {
        Long id = member.getId();
        String nickname = member.getNickname();
        
        return "성공";
}
```


**TO-BE**
- 로그아웃 구현
- 테스트 코드 작성
- 리팩토링

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
