### PR TITLE
fix : queryDsl에 seatId where절에 추가

### DIFF
--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewDetailCond.java
@@ -18,7 +18,7 @@ public class ReviewDetailCond {
 	private LocalDateTime createdAt;
 	private Integer floor;
 	private String section;
-	private String row;
+	private String seatRow;
 	private Integer seatNumber;
 	private Integer rating; // 평점
 	private Long likeAmount; // 좋아요 개수
@@ -34,7 +34,7 @@ public class ReviewDetailCond {
 			.createdAt(review.getMember().getCreatedAt())
 			.floor(review.getTheaterSeat().getFloor())
 			.section(review.getTheaterSeat().getSection())
-			.row(review.getTheaterSeat().getSeatRow())
+			.seatRow(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
 			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())

--- a/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/ReviewInfoCond.java
@@ -21,7 +21,7 @@ public class ReviewInfoCond {
 	private Long userId;
 	private Integer floor;
 	private String section;
-	private String row;
+	private String seatRow;
 	private Integer seatNumber;
 	private Integer rating; // 개인 평점
 	private Long likeAmount; // 좋아요 개수
@@ -36,7 +36,7 @@ public class ReviewInfoCond {
 			.userId(review.getMember().getId())
 			.floor(review.getTheaterSeat().getFloor())
 			.section(review.getTheaterSeat().getSection())
-			.row(review.getTheaterSeat().getSeatRow())
+			.seatRow(review.getTheaterSeat().getSeatRow())
 			.seatNumber(review.getTheaterSeat().getNumber())
 			.rating(review.getRating())
 			.likeAmount(review.getLikeAmount())

--- a/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
@@ -11,8 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-	List<Review> findAllByTheaterSeatId(Long id);
-
+	boolean existsByTheaterSeatId(Long theaterId);
 	@Modifying
 	@Query("delete from Comment c where c.review.id =:id ")
 	@Transactional

--- a/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/ReviewRepository.java
@@ -2,7 +2,6 @@ package com.example.seatchoice.repository;
 
 import com.example.seatchoice.entity.Review;
 import com.example.seatchoice.repository.reviewPaging.ReviewRepositoryCustom;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-	boolean existsByTheaterSeatId(Long theaterId);
 	@Modifying
 	@Query("delete from Comment c where c.review.id =:id ")
 	@Transactional

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryCustom.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryCustom.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ReviewRepositoryCustom {
-	Slice<ReviewInfoCond> searchBySlice(Long lastReviewId, Pageable pageable);
+	Slice<ReviewInfoCond> searchBySlice(Long lastReviewId, Long seatId, Pageable pageable);
 }

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
 	// 동적 쿼리를 위한 BooleanExpression
 	private BooleanExpression ltReviewId(Long reviewId) {
-		if (reviewId == null) {
+		if (reviewId == null) { // 요청이 처음일 때 where 절에 null을 주면 page size만큼 반환
 			return null;
 		}
 		return review.id.lt(reviewId);

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
@@ -4,17 +4,13 @@ import static com.example.seatchoice.entity.QReview.review;
 
 import com.example.seatchoice.dto.cond.ReviewInfoCond;
 import com.example.seatchoice.entity.Review;
-import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.type.ErrorCode;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -35,11 +31,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 			.limit(pageable.getPageSize() + 1) // limit보다 한 개 더 들고온다.
 			.fetch();
 
-		if (reviews.size() == 0) {
-			throw new CustomException(ErrorCode.NO_REVIEW_DATA,
-				HttpStatus.BAD_REQUEST);
+		List<ReviewInfoCond> reviewInfoConds = ReviewInfoCond.of(reviews);
+		if (reviewInfoConds == null) {
+			return null;
 		}
-		List<ReviewInfoCond> reviewInfoConds = new ArrayList<>(ReviewInfoCond.of(reviews));
 		return checkLastPage(pageable, reviewInfoConds);
 	}
 

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
@@ -23,11 +23,14 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Slice<ReviewInfoCond> searchBySlice(Long lastReviewId,
+	public Slice<ReviewInfoCond> searchBySlice(Long lastReviewId, Long seatId,
 		Pageable pageable) {
 		List<Review> reviews = queryFactory
 			.selectFrom(review)
-			.where(ltReviewId(lastReviewId)) // review.id < lastReviewId
+			.where(
+				ltReviewId(lastReviewId), // review.id < lastReviewId
+				review.theaterSeat.id.eq(seatId)
+			)
 			.orderBy(review.id.desc()) // 최신순으로 보여줌
 			.limit(pageable.getPageSize() + 1) // limit보다 한 개 더 들고온다.
 			.fetch();

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -114,13 +114,9 @@ public class ReviewService {
 
 	// 리뷰 목록 조회
 	public Slice<ReviewInfoCond> getReviews(Long lastReviewId, Long seatId, Pageable pageable) {
-		List<Review> reviews = reviewRepository.findAllByTheaterSeatId(seatId);
-
 		// 리뷰가 없을 때, null 반환
-		if (CollectionUtils.isEmpty(reviews)) return null;
+		if (!reviewRepository.existsByTheaterSeatId(seatId)) return null;
 
-		// 요청이 처음일 때
-		if (lastReviewId == null) lastReviewId = reviews.get(reviews.size() - 1).getId() + 1;
 		Slice<ReviewInfoCond> reviewInfoConds = reviewRepository
 			.searchBySlice(lastReviewId, seatId, pageable);
 

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -114,9 +114,6 @@ public class ReviewService {
 
 	// 리뷰 목록 조회
 	public Slice<ReviewInfoCond> getReviews(Long lastReviewId, Long seatId, Pageable pageable) {
-		// 리뷰가 없을 때, null 반환
-		if (!reviewRepository.existsByTheaterSeatId(seatId)) return null;
-
 		Slice<ReviewInfoCond> reviewInfoConds = reviewRepository
 			.searchBySlice(lastReviewId, seatId, pageable);
 

--- a/src/main/java/com/example/seatchoice/service/ReviewService.java
+++ b/src/main/java/com/example/seatchoice/service/ReviewService.java
@@ -120,9 +120,9 @@ public class ReviewService {
 		if (CollectionUtils.isEmpty(reviews)) return null;
 
 		// 요청이 처음일 때
-		if (lastReviewId == null) lastReviewId = reviews.get(reviews.size() - 1).getId();
+		if (lastReviewId == null) lastReviewId = reviews.get(reviews.size() - 1).getId() + 1;
 		Slice<ReviewInfoCond> reviewInfoConds = reviewRepository
-			.searchBySlice(lastReviewId, pageable);
+			.searchBySlice(lastReviewId, seatId, pageable);
 
 		return reviewInfoConds;
 	}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 프론트쪽에서 seatId로 리뷰 목록 조회 시, 모든 리뷰 목록이 조회되는 문제 발생
  - queryDsl where 조건에 seatId를 쓰지 않아서 생긴 문제기 때문에 조건절에 추가했습니다!
  - 관련 method에 seatId parameter 추가
- 불필요한 쿼리 요청문을 삭제 함으로써 리뷰 목록 조회 시 2번의 쿼리 -> 1번의 쿼리로 줄였습니다.
  - 코드 변경 전에는 아예 리뷰가 없는 좌석을 조회할 때 null 반환, 조회를 하다 더이상 조회할 리뷰가 없을 경우 예외처리를 했습니다.
    slice를 이용한 무한스크롤 구현으로 더이상 조회할 리뷰가 없을 때는 last가 true, 있을 때는 false를 프론트쪽으로 반환해주기 때문에
   프론트쪽에서 last가 true면 요청이 안 가도록 설정하여 더이상 조회할 리뷰가 없을 경우 예외처리가 필요없다고 생각했습니다.
   따라서 두 경우 다 null로 반환처리 해주는 것으로 변경했습니다.
   이로 인해 reviewRepository에서 existsByTheaterId를 따로 검증할 필요가 없고 reviewRepositoryImpl쪽에서  한번에 null 처리를 해주었습니다.
  
**TO-BE**
- 테스트 코드 및 리팩토링

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
