### PR TITLE
test : 이미지 파일 없는 리뷰 등록 테스트 구현

### DIFF
--- a/src/main/java/com/example/seatchoice/dto/param/ReviewModifyParam.java
+++ b/src/main/java/com/example/seatchoice/dto/param/ReviewModifyParam.java
@@ -1,7 +1,7 @@
 package com.example.seatchoice.dto.param;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +13,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ReviewModifyParam {
 	@NotBlank(message = "필수 입력입니다.")
-	@Pattern(regexp = "^.{1,300}$", message = "리뷰내용은 1~300자로 내로 입력하세요.")
+	@Size(min = 1, max = 300, message = "리뷰내용은 1~300자로 내로 입력하세요.")
 	private String content;
 
 	private Integer rating;

--- a/src/main/java/com/example/seatchoice/dto/param/ReviewParam.java
+++ b/src/main/java/com/example/seatchoice/dto/param/ReviewParam.java
@@ -2,8 +2,8 @@ package com.example.seatchoice.dto.param;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +28,7 @@ public class ReviewParam {
 	private Integer seatNumber;
 
 	@NotBlank(message = "필수 입력입니다.")
-	@Pattern(regexp = "^.{1,300}$", message = "리뷰내용은 1~300자로 내로 입력하세요.")
+	@Size(min = 1, max = 300, message = "리뷰내용은 1~300자로 내로 입력하세요.")
 	private String content;
 
 	private Integer rating;

--- a/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
@@ -1,0 +1,109 @@
+package com.example.seatchoice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.seatchoice.dto.cond.ReviewCond;
+import com.example.seatchoice.dto.param.ReviewParam;
+import com.example.seatchoice.entity.Member;
+import com.example.seatchoice.entity.Review;
+import com.example.seatchoice.entity.Theater;
+import com.example.seatchoice.entity.TheaterSeat;
+import com.example.seatchoice.repository.ImageRepository;
+import com.example.seatchoice.repository.MemberRepository;
+import com.example.seatchoice.repository.ReviewLikeRepository;
+import com.example.seatchoice.repository.ReviewRepository;
+import com.example.seatchoice.repository.TheaterRepository;
+import com.example.seatchoice.repository.TheaterSeatRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class ReviewServiceTest {
+	@Mock
+	private ReviewRepository reviewRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private ImageRepository imageRepository;
+	@Mock
+	private TheaterSeatRepository theaterSeatRepository;
+	@Mock
+	private TheaterRepository theaterRepository;
+	@Mock
+	private ReviewLikeRepository reviewLikeRepository;
+	@Mock
+	private ImageService imageService;
+
+	@InjectMocks
+	private ReviewService reviewService;
+
+	@Test
+	@DisplayName("리뷰 등록 성공 - 이미지 업로드 안 했을 경우")
+	void createSuccessWithoutImageFiles() {
+	    // given
+		Member member = new Member();
+		Theater theater = new Theater();
+		theater.setId(1L);
+		List<TheaterSeat> theaterSeats = Arrays.asList(
+			TheaterSeat.builder()
+				.theater(theater)
+				.floor(1)
+				.section("OP")
+				.seatRow("1")
+				.number(1)
+				.rating(0.0)
+				.reviewAmount(0L)
+				.build(),
+			TheaterSeat.builder()
+				.theater(theater)
+				.floor(2)
+				.section("OP")
+				.seatRow("1")
+				.number(1)
+				.rating(0.0)
+				.reviewAmount(0L)
+				.build()
+		);
+		ReviewParam request = new ReviewParam(1, "OP", "1", 1, "좌석 괜찮습니다!", 4);
+
+		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(theaterSeats);
+		given(memberRepository.getReferenceById(anyLong())).willReturn(member);
+		given(reviewRepository.save(any())).willReturn(
+			Review.builder()
+				.member(member)
+				.theaterSeat(theaterSeats.get(0))
+				.rating(4)
+				.content("좌석 괜찮습니다!")
+				.commentAmount(0L)
+				.likeAmount(0L)
+				.build()
+		);
+
+		ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
+
+	    // when
+		ReviewCond reviewCond = reviewService.createReview(7L, 562L, null, request);
+
+		// then
+		verify(reviewRepository, times(1)).save(captor.capture());
+		assertEquals(4, reviewCond.getRating());
+		assertEquals("좌석 괜찮습니다!", reviewCond.getContent());
+	}
+
+}

--- a/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 
 import com.example.seatchoice.dto.cond.ReviewCond;
 import com.example.seatchoice.dto.param.ReviewParam;
-import com.example.seatchoice.entity.Image;
 import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.entity.Review;
 import com.example.seatchoice.entity.Theater;
@@ -23,11 +22,6 @@ import com.example.seatchoice.repository.ReviewRepository;
 import com.example.seatchoice.repository.TheaterRepository;
 import com.example.seatchoice.repository.TheaterSeatRepository;
 import com.example.seatchoice.type.ErrorCode;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -37,9 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
@@ -105,5 +105,4 @@ public class ReviewServiceTest {
 		assertEquals(4, reviewCond.getRating());
 		assertEquals("좌석 괜찮습니다!", reviewCond.getContent());
 	}
-
 }

--- a/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/ReviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.seatchoice.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -9,16 +10,23 @@ import static org.mockito.Mockito.verify;
 
 import com.example.seatchoice.dto.cond.ReviewCond;
 import com.example.seatchoice.dto.param.ReviewParam;
+import com.example.seatchoice.entity.Image;
 import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.entity.Review;
 import com.example.seatchoice.entity.Theater;
 import com.example.seatchoice.entity.TheaterSeat;
+import com.example.seatchoice.exception.CustomException;
 import com.example.seatchoice.repository.ImageRepository;
 import com.example.seatchoice.repository.MemberRepository;
 import com.example.seatchoice.repository.ReviewLikeRepository;
 import com.example.seatchoice.repository.ReviewRepository;
 import com.example.seatchoice.repository.TheaterRepository;
 import com.example.seatchoice.repository.TheaterSeatRepository;
+import com.example.seatchoice.type.ErrorCode;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +37,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -104,5 +113,45 @@ public class ReviewServiceTest {
 		verify(reviewRepository, times(1)).save(captor.capture());
 		assertEquals(4, reviewCond.getRating());
 		assertEquals("좌석 괜찮습니다!", reviewCond.getContent());
+		assertEquals(null, reviewCond.getImages());
+	}
+
+	@Test
+	@DisplayName("리뷰 생성 실패 - 리뷰 존재하지 않는 경우")
+	void createReview_notFountSeat() {
+	    // given
+		Member member = new Member();
+		Theater theater = new Theater();
+		theater.setId(1L);
+		List<TheaterSeat> theaterSeats = Arrays.asList(
+			TheaterSeat.builder()
+				.theater(theater)
+				.floor(1)
+				.section("OP")
+				.seatRow("1")
+				.number(2)
+				.rating(0.0)
+				.reviewAmount(0L)
+				.build(),
+			TheaterSeat.builder()
+				.theater(theater)
+				.floor(2)
+				.section("OP")
+				.seatRow("1")
+				.number(1)
+				.rating(0.0)
+				.reviewAmount(0L)
+				.build()
+		);
+		ReviewParam request = new ReviewParam(1, "OP", "1", 1, "좌석 괜찮습니다!", 4);
+
+		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(theaterSeats);
+
+		// when
+		CustomException customException = assertThrows(CustomException.class,
+			() -> reviewService.createReview(7L, 562L, null, request));
+
+		// then
+		assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_SEAT);
 	}
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 이미지 파일 없는 리뷰 등록 테스트 구현
- multipartfile을 어떻게 구현해야 할지 몰라서 찾아보고 이미지 파일 있는 리뷰 등록 테스트 구현하려고 합니다!
- 리뷰 수정 및 등록 시 엔터 등록 안되는 부분 수정
   - @Pattern(regexp = "^.{1,300}$") -> @Pattern(regexp = "^((.|\\n)*){1,300}$")
   - 그러나 글자 마지막 부분 공백을 글자수에 포함하지 않아 공백으로 인해 300글자가 넘어가도 에러 잡지 못하는 문제 발생
   - @Pattern(regexp = "^((.|\\n)*){1,300}$") -> @Size(min = 1, max = 300) 수정
   - 엔터, 공백 문제 모두 해결
- 리뷰 등록 실패 테스트 코드 구현(좌석이 없는 경우)

**TO-BE**
- 이미지 파일 있는 리뷰 등록 테스트 구현

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
