### PR TITLE
Feature/theater-list : 공연장 목록 조회 구현

### DIFF
--- a/src/main/java/com/example/seatchoice/controller/TheaterController.java
+++ b/src/main/java/com/example/seatchoice/controller/TheaterController.java
@@ -1,0 +1,25 @@
+package com.example.seatchoice.controller;
+
+import com.example.seatchoice.dto.cond.TheaterResponse;
+import com.example.seatchoice.service.TheaterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/theaters")
+
+public class TheaterController {
+	private final TheaterService theaterService;
+
+	@GetMapping("/{facilityId}")
+	public ResponseEntity<TheaterResponse> getListOfFacility(@PathVariable Long facilityId) {
+
+		return ResponseEntity.ok(theaterService.getListOfFacility(facilityId));
+	}
+
+}

--- a/src/main/java/com/example/seatchoice/dto/cond/TheaterResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/TheaterResponse.java
@@ -1,0 +1,50 @@
+package com.example.seatchoice.dto.cond;
+
+import com.example.seatchoice.entity.Facility;
+import com.example.seatchoice.entity.Theater;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterResponse {
+
+	private Long facilityId;
+	private String facilityName;
+	private List<TheaterDto> theaterList = new ArrayList<>();
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class TheaterDto {
+		private Long id;
+		private String name;
+		private int seatCnt;
+
+		public static TheaterDto of(Theater theater) {
+			return TheaterDto.builder()
+				.id(theater.getId())
+				.name(theater.getName())
+				.seatCnt(theater.getSeatCnt())
+				.build();
+		}
+	}
+
+	public static TheaterResponse of(List<Theater> theaterList, Facility facility) {
+		return TheaterResponse.builder()
+			.facilityId(facility.getId())
+			.facilityName(facility.getName())
+			.theaterList(theaterList.stream()
+				.map(TheaterDto::of).collect(Collectors.toList()))
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/seatchoice/repository/TheaterRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/TheaterRepository.java
@@ -1,6 +1,8 @@
 package com.example.seatchoice.repository;
 
+import com.example.seatchoice.entity.Facility;
 import com.example.seatchoice.entity.Theater;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
 
 	Theater findByNameAndFacility_Name(String name, String facilityName);
+
+	List<Theater> findAllByFacility(Facility facility);
 
 }

--- a/src/main/java/com/example/seatchoice/service/TheaterService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterService.java
@@ -1,0 +1,34 @@
+package com.example.seatchoice.service;
+
+import static com.example.seatchoice.type.ErrorCode.NOT_FOUND_FACILITY;
+
+import com.example.seatchoice.dto.cond.TheaterResponse;
+import com.example.seatchoice.entity.Facility;
+import com.example.seatchoice.entity.Theater;
+import com.example.seatchoice.exception.CustomException;
+import com.example.seatchoice.repository.FacilityRepository;
+import com.example.seatchoice.repository.TheaterRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TheaterService {
+
+	private final TheaterRepository theaterRepository;
+	private final FacilityRepository facilityRepository;
+
+
+	public TheaterResponse getListOfFacility(Long facilityId) {
+
+		Facility facility = facilityRepository.findById(facilityId)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_FACILITY, HttpStatus.NOT_FOUND));
+
+		List<Theater> theaterList = theaterRepository.findAllByFacility(facility);
+
+		return TheaterResponse.of(theaterList, facility);
+	}
+
+}

--- a/src/main/java/com/example/seatchoice/type/ErrorCode.java
+++ b/src/main/java/com/example/seatchoice/type/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	EMPTY_TOKEN("토큰이 존재하지 않습니다."),
 	AUTHORIZATION_KEY_DOES_NOT_EXIST("Authorization key가 존재하지 않습니다."),
 	NOT_FOUND_MEMBER("해당 유저가 존재하지 않습니다."),
+	NOT_FOUND_FACILITY("해당 시설이 존재하지 않습니다."),
 	NOT_FOUND_THEATER("해당 공연장이 존재하지 않습니다."),
 	NOT_FOUND_CHATROOM("해당 채팅방이 존재하지 않습니다."),
 	NOT_FOUND_SEAT("해당 공연좌석이 존재하지 않습니다."),

--- a/src/test/java/com/example/seatchoice/service/TheaterServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/TheaterServiceTest.java
@@ -1,0 +1,65 @@
+package com.example.seatchoice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.example.seatchoice.dto.cond.TheaterResponse;
+import com.example.seatchoice.entity.Facility;
+import com.example.seatchoice.entity.Theater;
+import com.example.seatchoice.repository.FacilityRepository;
+import com.example.seatchoice.repository.TheaterRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class TheaterServiceTest {
+
+	@Mock
+	private TheaterRepository theaterRepository;
+	@Mock
+	private FacilityRepository facilityRepository;
+	@InjectMocks
+	private TheaterService theaterService;
+
+	@Test
+	void getListOfFacility() {
+		// given
+		Facility facility = Facility.builder()
+			.name("서울아트센터").build();
+		facility.setId(1L);
+		Theater theater1 = Theater.builder().name("백엔홀").seatCnt(230).build();
+		theater1.setId(11L);
+		Theater theater2 = Theater.builder().name("프엔홀").seatCnt(500).build();
+		theater2.setId(12L);
+		List<Theater> theaterList = List.of(theater1, theater2);
+
+		given(facilityRepository.findById(anyLong()))
+			.willReturn(Optional.of(facility));
+		given(theaterRepository.findAllByFacility(any()))
+			.willReturn(theaterList);
+
+		// when
+		TheaterResponse response = theaterService.getListOfFacility(1L);
+
+		// then
+		assertEquals(response.getFacilityId(), 1L);
+		assertEquals(response.getFacilityName(), "서울아트센터");
+		assertEquals(response.getTheaterList().size(), 2);
+		assertEquals(response.getTheaterList().get(0).getId(), 11L);
+		assertEquals(response.getTheaterList().get(1).getId(), 12L);
+		assertEquals(response.getTheaterList().get(0).getName(), "백엔홀");
+		assertEquals(response.getTheaterList().get(1).getName(), "프엔홀");
+		assertEquals(response.getTheaterList().get(0).getSeatCnt(), 230);
+		assertEquals(response.getTheaterList().get(1).getSeatCnt(), 500);
+
+	}
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 공연장 목록 조회
- api 명세서를 수정했습니다
=> /api/theater/{facility_id} -> /api/theaters/{facility_id}
=> 중복되는 응답 값(시설id, 시설명) 빼고, 공연장을 리스트로 받게 변경
- 테스트 완료

**TO-BE**
- 댓글 작성 500 에러 이슈 해결
- elasticsearch 바인딩 문제 해결하기 !!!!
- 멀티 모듈에 대해 조사

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
