### PR TITLE
feat : 카카오 로그아웃 기능 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - "6379:6379"
     networks:
       - elastic
+    volumes:
+      - /home/ubuntu/redis:/data
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4

--- a/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/seatchoice/config/JwtAuthenticationFilter.java
@@ -6,7 +6,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.service.oauth.TokenService;
+import com.example.seatchoice.service.auth.TokenService;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
 import java.io.IOException;

--- a/src/main/java/com/example/seatchoice/config/SecurityConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.example.seatchoice.config;
 
-import com.example.seatchoice.service.oauth.TokenService;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+import com.example.seatchoice.service.auth.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -26,22 +28,22 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.authorizeRequests()
 			.antMatchers(
-				"/",
-				"/api/**", // 임시 설정
-				"/api/reissue/refresh-token",
+				POST,
 				"/api/oauth/{provider}/login"
+			).permitAll()
+			.antMatchers(
+				GET,
+				"/api/theaters/**",
+				"/api/search",
+				"/api/reviews",
+				"/api/reviews/**"
 			).permitAll()
 			// 유저 권한이 필요한 api 추가
 			.antMatchers(
-				"/api/likes/**",
-				"/api/theaters/**/reviews"
-			).hasRole("USER")
-			.antMatchers(HttpMethod.POST, "/api/reviews/**")
-			.hasRole("USER")
-			.antMatchers(HttpMethod.DELETE, "/api/reviews/**")
-			.hasRole("USER")
-			.antMatchers("/exchange/**", "/pub/**")
-			.hasRole("USER");
+				"/api/**",
+				"/exchange/**",
+				"/pub/**"
+			).hasRole("USER");
 
 		http.addFilterBefore(new JwtAuthenticationFilter(tokenService),
 			UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/seatchoice/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/seatchoice/config/websocket/StompHandler.java
@@ -8,7 +8,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.service.oauth.TokenService;
+import com.example.seatchoice.service.auth.TokenService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;

--- a/src/main/java/com/example/seatchoice/controller/MemberController.java
+++ b/src/main/java/com/example/seatchoice/controller/MemberController.java
@@ -1,28 +1,34 @@
 package com.example.seatchoice.controller;
 
 import com.example.seatchoice.dto.auth.Token;
-import com.example.seatchoice.dto.common.ApiResponse;
+import com.example.seatchoice.entity.Member;
 import com.example.seatchoice.service.MemberService;
+import com.example.seatchoice.service.auth.TokenService;
 import java.io.IOException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/oauth/{provider}")
 public class MemberController {
 
 	private final MemberService memberService;
+	private final TokenService tokenService;
 
 	private final String REFRESH_TOKEN_KEY = "refreshToken";
 
-	@PostMapping("/api/oauth/{provider}/login")
-	public ApiResponse oauthLogin(
+	@PostMapping("/login")
+	public ResponseEntity<Void>  oauthLogin(
 		@RequestParam String code, @PathVariable("provider") String provider, HttpServletResponse response)
 		throws IOException, ParseException {
 
@@ -34,6 +40,17 @@ public class MemberController {
 		cookie.setPath("/");
 		response.addCookie(cookie);
 
-		return new ApiResponse();
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> oauthLogin(
+		@AuthenticationPrincipal Member member, @PathVariable("provider") String provider, HttpServletResponse response)
+		throws IOException {
+
+		memberService.oauthLogout(member.getId(), provider);
+		tokenService.resetHeader(response);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/example/seatchoice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seatchoice/exception/GlobalExceptionHandler.java
@@ -1,16 +1,13 @@
 package com.example.seatchoice.exception;
 
-import static com.example.seatchoice.type.ErrorCode.ERROR_CODE_500;
 import static com.example.seatchoice.type.ErrorCode.METHOD_ARGUMENT_NOT_VALID;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.example.seatchoice.dto.common.ErrorResponse;
 import com.example.seatchoice.dto.validation.ValidErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -30,9 +27,9 @@ public class GlobalExceptionHandler {
 			e.getFieldError().getDefaultMessage(), BAD_REQUEST);
 	}
 
-	@ResponseStatus(INTERNAL_SERVER_ERROR)
-	@ExceptionHandler
-	public ResponseEntity<ErrorResponse> handleServerErrorException(Exception e) {
-		return ErrorResponse.from(ERROR_CODE_500, INTERNAL_SERVER_ERROR);
-	}
+//	@ResponseStatus(INTERNAL_SERVER_ERROR)
+//	@ExceptionHandler
+//	public ResponseEntity<ErrorResponse> handleServerErrorException(Exception e) {
+//		return ErrorResponse.from(ERROR_CODE_500, INTERNAL_SERVER_ERROR);
+//	}
 }

--- a/src/main/java/com/example/seatchoice/service/MemberService.java
+++ b/src/main/java/com/example/seatchoice/service/MemberService.java
@@ -5,7 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.example.seatchoice.dto.auth.Token;
 import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.service.oauth.OauthService;
+import com.example.seatchoice.service.auth.OauthService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
@@ -23,6 +23,16 @@ public class MemberService {
 		switch (provider) {
 			case KAKAO:
 				return oauthService.kakaoLogin(code);
+			default:
+				throw new CustomException(UNSUPPORTED_PROVIDER, BAD_REQUEST);
+		}
+	}
+
+	public void oauthLogout(Long memberId, String provider) throws IOException {
+		switch (provider) {
+			case KAKAO:
+				oauthService.kakaoLogout(memberId);
+				return;
 			default:
 				throw new CustomException(UNSUPPORTED_PROVIDER, BAD_REQUEST);
 		}

--- a/src/main/java/com/example/seatchoice/service/auth/KakaoService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/KakaoService.java
@@ -1,4 +1,4 @@
-package com.example.seatchoice.service.oauth;
+package com.example.seatchoice.service.auth;
 
 import static com.example.seatchoice.type.LoginType.KAKAO;
 import static com.example.seatchoice.type.RequestMethod.GET;
@@ -40,6 +40,9 @@ public class KakaoService {
 
 	@Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
 	private String userInfoUri;
+
+	@Value("${spring.security.oauth2.client.provider.kakao.logout-uri}")
+	private String logoutUri;
 
 	public String getToken(String code) throws IOException, ParseException {
 		URL url = new URL(tokenUri);
@@ -114,4 +117,10 @@ public class KakaoService {
 			.build();
 	}
 
+	public void logout(String accessToken) throws IOException {
+		URL url = new URL(logoutUri);
+		HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+		urlConnection.setRequestProperty("Authorization", accessToken);
+		urlConnection.setRequestMethod(POST.name());
+	}
 }

--- a/src/main/java/com/example/seatchoice/service/auth/OauthService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/OauthService.java
@@ -1,4 +1,4 @@
-package com.example.seatchoice.service.oauth;
+package com.example.seatchoice.service.auth;
 
 import static com.example.seatchoice.type.MemberRole.ROLE_USER;
 
@@ -68,5 +68,16 @@ public class OauthService {
 		}
 
 		return member;
+	}
+
+	public void kakaoLogout(Long memberId) throws IOException {
+		Object kakaoAccessToken = redisTemplate.opsForHash().get(memberId, "accessToken");
+
+		if (kakaoAccessToken == null) {
+			return;
+		}
+
+		kakaoService.logout(kakaoAccessToken.toString());
+		redisTemplate.delete(memberId);
 	}
 }

--- a/src/main/java/com/example/seatchoice/service/auth/TokenService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/TokenService.java
@@ -1,4 +1,4 @@
-package com.example.seatchoice.service.oauth;
+package com.example.seatchoice.service.auth;
 
 import static com.example.seatchoice.type.ErrorCode.AUTHORIZATION_KEY_DOES_NOT_EXIST;
 import static com.example.seatchoice.type.ErrorCode.EXPIRED_REFRESH_TOKEN;
@@ -166,7 +166,7 @@ public class TokenService{
 	}
 
 	// 만료된 access, refresh token 정보 삭제
-	private void resetHeader(HttpServletResponse response) {
+	public void resetHeader(HttpServletResponse response) {
 		response.setHeader("Authorization", null);
 		Cookie cookie = new Cookie("refreshToken", null);
 		cookie.setHttpOnly(true);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,7 @@ spring:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
+            logout-uri: https://kapi.kakao.com/v1/user/logout
             user-name-attribute: id
 
   batch:

--- a/src/test/java/com/example/seatchoice/service/MemberServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/MemberServiceTest.java
@@ -1,14 +1,15 @@
 package com.example.seatchoice.service;
 
 import static com.example.seatchoice.type.ErrorCode.UNSUPPORTED_PROVIDER;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.example.seatchoice.dto.auth.Token;
 import com.example.seatchoice.exception.CustomException;
-import com.example.seatchoice.service.oauth.OauthService;
+import com.example.seatchoice.service.auth.OauthService;
 import java.io.IOException;
 import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/seatchoice/service/auth/OauthServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/auth/OauthServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.seatchoice.service.oauth;
+package com.example.seatchoice.service.auth;
 
 import static com.example.seatchoice.type.LoginType.KAKAO;
 import static com.example.seatchoice.type.MemberRole.ROLE_USER;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**1. kakao logout 기능 추가**
- 로그인한 유저만 로그아웃 기능을 사용할 수 있습니다.
- redis 에서 member_id에 해당하는 kakao access token을 불러옵니다.
- access_token으로 카카오 로그아웃 api를 사용합니다.
- 헤더에 access_token, refresh_token 정보를 null로 초기화하며 로그아웃을 마칩니다.

**2. redis volumes 추가**

**TO-BE**
- kakao access token이 만료일 경우 로직 추가

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
