### PR TITLE
Feature/theater seat test 구현 및 리팩토링

### DIFF
--- a/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
+++ b/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
@@ -1,8 +1,10 @@
 package com.example.seatchoice.controller;
 
-import com.example.seatchoice.dto.common.ApiResponse;
+import com.example.seatchoice.dto.cond.TheaterSeatResponse;
 import com.example.seatchoice.service.TheaterSeatService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +18,7 @@ public class TheaterSeatController {
 	private final TheaterSeatService theaterSeatService;
 
 	@GetMapping("/theaters/{theaterId}/seats")
-	public ApiResponse<?> getSeatsWithReviews(@PathVariable Long theaterId) {
-		return new ApiResponse<>(theaterSeatService.getSeatsWithReviews(theaterId));
+	public ResponseEntity<List<TheaterSeatResponse>> getSeatsWithReviews(@PathVariable Long theaterId) {
+		return ResponseEntity.ok(theaterSeatService.getSeatsWithReviews(theaterId));
 	}
 }

--- a/src/main/java/com/example/seatchoice/dto/cond/TheaterSeatResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/cond/TheaterSeatResponse.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TheaterSeatCond {
+public class TheaterSeatResponse {
 	private Long seatId;
 	private Integer floor;
 	private String section;
@@ -21,8 +21,8 @@ public class TheaterSeatCond {
 	private Long reviewAmount;
 	private Double rating; // 평점
 
-	public static TheaterSeatCond from(TheaterSeat seat) {
-		return TheaterSeatCond.builder()
+	public static TheaterSeatResponse from(TheaterSeat seat) {
+		return TheaterSeatResponse.builder()
 			.seatId(seat.getId())
 			.floor(seat.getFloor())
 			.section(seat.getSection())

--- a/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
@@ -1,10 +1,10 @@
 package com.example.seatchoice.service;
 
-import com.example.seatchoice.dto.cond.TheaterSeatCond;
+import com.example.seatchoice.dto.cond.TheaterSeatResponse;
 import com.example.seatchoice.entity.TheaterSeat;
 import com.example.seatchoice.repository.TheaterSeatRepository;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -14,20 +14,16 @@ import org.springframework.util.CollectionUtils;
 public class TheaterSeatService {
 
 	private final TheaterSeatRepository theaterSeatRepository;
-	public List<TheaterSeatCond> getSeatsWithReviews(Long theaterId) {
+	public List<TheaterSeatResponse> getSeatsWithReviews(Long theaterId) {
 		List<TheaterSeat> seats = theaterSeatRepository.findAllByTheaterId(theaterId);
 
-		List<TheaterSeatCond> theaterSeatConds = new ArrayList<>();
 		if (!CollectionUtils.isEmpty(seats)) {
-			for (TheaterSeat seat : seats) {
-				if (seat.getReviewAmount() > 0) {
-					theaterSeatConds.add(TheaterSeatCond.from(seat));
-				}
-			}
+			return seats.stream()
+				.filter(t -> t.getReviewAmount() > 0)
+				.map(TheaterSeatResponse::from)
+				.collect(Collectors.toList());
 		} else {
-			theaterSeatConds = null;
+			return null;
 		}
-
-		return theaterSeatConds;
 	}
 }

--- a/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
@@ -22,8 +22,7 @@ public class TheaterSeatService {
 				.filter(t -> t.getReviewAmount() > 0)
 				.map(TheaterSeatResponse::from)
 				.collect(Collectors.toList());
-		} else {
-			return null;
 		}
+		return null;
 	}
 }

--- a/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.seatchoice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.example.seatchoice.dto.cond.TheaterSeatResponse;
+import com.example.seatchoice.entity.TheaterSeat;
+import com.example.seatchoice.repository.TheaterSeatRepository;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class TheaterSeatServiceTest {
+	@Mock
+	private TheaterSeatRepository theaterSeatRepository;
+	@InjectMocks
+	private TheaterSeatService theaterSeatService;
+
+	@Test
+	@DisplayName("리뷰가 있는 좌석 조회 성공 - 좌석이 있을 경우")
+	void getSeatsWithReviewsSuccess() {
+	    // given
+		List<TheaterSeat> seats = Arrays.asList(
+			TheaterSeat.builder()
+				.floor(1)
+				.section("A")
+				.seatRow("1")
+				.number(1)
+				.reviewAmount(0L)
+				.rating(5.0)
+				.build(),
+			TheaterSeat.builder()
+				.floor(2)
+				.section("A")
+				.seatRow("1")
+				.number(1)
+				.reviewAmount(2L)
+				.rating(3.0)
+				.build()
+		);
+
+		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(seats);
+
+	    // when
+		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeatsWithReviews(1L);
+
+		// then
+		assertEquals(1, seatsWithReviews.size());
+		assertEquals(2, seatsWithReviews.get(0).getFloor());
+	}
+
+	@Test
+	@DisplayName("리뷰가 있는 좌석 조회 성공 - 좌석이 없을 경우")
+	void getSeatsWithReviews_noSeats() {
+		// given
+		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(null);
+
+		// when
+		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeatsWithReviews(1L);
+
+		// then
+		assertEquals(null, seatsWithReviews);
+	}
+}

--- a/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @ExtendWith(MockitoExtension.class)
 public class TheaterSeatServiceTest {
+
 	@Mock
 	private TheaterSeatRepository theaterSeatRepository;
 	@InjectMocks
@@ -28,7 +29,7 @@ public class TheaterSeatServiceTest {
 	@Test
 	@DisplayName("리뷰가 있는 좌석 조회 성공 - 좌석이 있을 경우")
 	void getSeatsWithReviewsSuccess() {
-	    // given
+		// given
 		List<TheaterSeat> seats = Arrays.asList(
 			TheaterSeat.builder()
 				.floor(1)
@@ -50,7 +51,7 @@ public class TheaterSeatServiceTest {
 
 		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(seats);
 
-	    // when
+		// when
 		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeatsWithReviews(1L);
 
 		// then


### PR DESCRIPTION
### 변경사항
**AS-IS**
- TheaterSeatCond -> TheaterSeatResponse 로 변경
- ApiResponse -> ResponseEntity 로 변경
- 기존 코드는 TheaterSeatResponse list를 생성해 for문으로 리뷰가 있는 좌석을 list에 저장
   -> stream을 이용하여 람다함수형식으로 변경
  - list를 따로 할당하지 않아도 되고, for문과 if문을 따로 쓰지 않고 stream을 이용하여 깔끔한 코드 가능
- TheaterSeatService 테스트 코드 구현

**TO-BE**
- 좋아요 부분 테스트 코드 작성 및 리팩토링

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
