### PR TITLE
feat : access-token 재발급 기능 추가

### DIFF
--- a/src/main/java/com/example/seatchoice/config/SecurityConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 			).permitAll()
 			.antMatchers(
 				GET,
+				"/api/auth/tokens",
 				"/api/theaters/**",
 				"/api/search",
 				"/api/reviews",

--- a/src/main/java/com/example/seatchoice/controller/MemberController.java
+++ b/src/main/java/com/example/seatchoice/controller/MemberController.java
@@ -6,11 +6,13 @@ import com.example.seatchoice.service.MemberService;
 import com.example.seatchoice.service.auth.TokenService;
 import java.io.IOException;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/oauth/{provider}")
+@RequestMapping("/api")
 public class MemberController {
 
 	private final MemberService memberService;
@@ -27,7 +29,7 @@ public class MemberController {
 
 	private final String REFRESH_TOKEN_KEY = "refreshToken";
 
-	@PostMapping("/login")
+	@PostMapping("/oauth/{provider}/login")
 	public ResponseEntity<Void>  oauthLogin(
 		@RequestParam String code, @PathVariable("provider") String provider, HttpServletResponse response)
 		throws IOException, ParseException {
@@ -43,13 +45,21 @@ public class MemberController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/logout")
+	@PostMapping("/oauth/{provider}/logout")
 	public ResponseEntity<Void> oauthLogin(
 		@AuthenticationPrincipal Member member, @PathVariable("provider") String provider, HttpServletResponse response)
 		throws IOException {
 
 		memberService.oauthLogout(member.getId(), provider);
 		tokenService.resetHeader(response);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/auth/tokens")
+	public ResponseEntity<Void> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+		String accessToken = tokenService.reissueAccessToken(request, response);
+		response.setHeader("Authorization", accessToken);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/example/seatchoice/controller/MemberController.java
+++ b/src/main/java/com/example/seatchoice/controller/MemberController.java
@@ -46,7 +46,7 @@ public class MemberController {
 	}
 
 	@PostMapping("/oauth/{provider}/logout")
-	public ResponseEntity<Void> oauthLogin(
+	public ResponseEntity<Void> oauthLogout(
 		@AuthenticationPrincipal Member member, @PathVariable("provider") String provider, HttpServletResponse response)
 		throws IOException {
 

--- a/src/main/java/com/example/seatchoice/service/auth/TokenService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/TokenService.java
@@ -18,7 +18,9 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -56,7 +58,9 @@ public class TokenService{
 	}
 
 	public String createToken(Member member) {
-		Claims claims = Jwts.claims().setSubject(String.valueOf(member.getId()));
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", member.getId());
+		claims.put("nickname", member.getNickname());
 		Date now = new Date();
 
 		String accessToken = Jwts.builder()


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
**1. access-token 재발급 기능 추가**
- 현재 채팅 api 제외 다른 api는 서버에서 access-token 만료 시 재발급을 자동으로 해주고 있습니다.
- 하지만 채팅 쪽은 stomp handler에서 token 검증을 따로 하면서, 재발급 과정까지는 할 수 없어서 따로 api를 만들었습니다.

**2. access-token에 닉네임 정보 추가**
- 프론트 요청으로 토큰에 닉네임 정보를 추가했습니다.


**TO-BE**

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
