### PR TITLE
fix : jwt nickname 한글 깨짐 해결을 위한 utf-8 설정

### DIFF
--- a/src/main/java/com/example/seatchoice/service/auth/TokenService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/TokenService.java
@@ -3,6 +3,7 @@ package com.example.seatchoice.service.auth;
 import static com.example.seatchoice.type.ErrorCode.AUTHORIZATION_KEY_DOES_NOT_EXIST;
 import static com.example.seatchoice.type.ErrorCode.EXPIRED_REFRESH_TOKEN;
 import static com.example.seatchoice.type.ErrorCode.NOT_FOUND_MEMBER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -15,6 +16,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -56,11 +58,13 @@ public class TokenService{
 	}
 
 	public String createToken(Member member) {
-//		Map<String, Object> claims = new HashMap<>();
-//		claims.put("id", member.getId());
-//		claims.put("nickname", member.getNickname());
 		Claims claims = Jwts.claims().setSubject(String.valueOf(member.getId()));
-		claims.put("nickname", member.getNickname());
+
+		// nickname utf-8 encoding
+		byte[] bytes = member.getNickname().getBytes(UTF_8);
+		String utf8EncodedNickname = new String(bytes, UTF_8);
+		claims.put("nickname", utf8EncodedNickname);
+
 		Date now = new Date();
 
 		String accessToken = Jwts.builder()

--- a/src/main/java/com/example/seatchoice/service/auth/TokenService.java
+++ b/src/main/java/com/example/seatchoice/service/auth/TokenService.java
@@ -58,12 +58,8 @@ public class TokenService{
 	}
 
 	public String createToken(Member member) {
-		Claims claims = Jwts.claims().setSubject(String.valueOf(member.getId()));
-
-		// nickname utf-8 encoding
-		byte[] bytes = member.getNickname().getBytes(UTF_8);
-		String utf8EncodedNickname = new String(bytes, UTF_8);
-		claims.put("nickname", utf8EncodedNickname);
+		Claims claims = Jwts.claims().setSubject(member.getNickname());
+		claims.put("memberId", member.getId());
 
 		Date now = new Date();
 
@@ -153,13 +149,13 @@ public class TokenService{
 	}
 
 	public Long getMemberId(String token) {
-		String memberId = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+		String memberId = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get("memberId").toString();
 		return Long.valueOf(memberId);
 	}
 
 	public Long getMemberIdFromRefreshToken(String refreshToken) {
 		String memberId =
-			Jwts.parser().setSigningKey(refreshSecretKey).parseClaimsJws(refreshToken).getBody().getSubject();
+			Jwts.parser().setSigningKey(refreshSecretKey).parseClaimsJws(refreshToken).getBody().get("memberId").toString();
 		return Long.valueOf(memberId);
 	}
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. 프론트에서 jwt에 담긴 닉네임을 사용하는데 한글 깨짐 문제 발생
 - 시도 1)  닉네임 utf-8 인코딩 코드 추가
 - 시도 2) jwt subject member_id 에서 nickname으로 수정

**TO-BE**

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
