### PR TITLE
Feature/theater seat fix

### DIFF
--- a/src/main/java/com/example/seatchoice/config/SwaggerConfig.java
+++ b/src/main/java/com/example/seatchoice/config/SwaggerConfig.java
@@ -21,7 +21,8 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 			name = "zeropepsi",
 			url = "https://github.com/seatchoice"
 		)
-	)
+	),
+	servers = @Server(url = "/", description = "Default Server URL")
 )
 public class SwaggerConfig {
 

--- a/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
+++ b/src/main/java/com/example/seatchoice/controller/TheaterSeatController.java
@@ -18,7 +18,7 @@ public class TheaterSeatController {
 	private final TheaterSeatService theaterSeatService;
 
 	@GetMapping("/theaters/{theaterId}/seats")
-	public ResponseEntity<List<TheaterSeatResponse>> getSeatsWithReviews(@PathVariable Long theaterId) {
-		return ResponseEntity.ok(theaterSeatService.getSeatsWithReviews(theaterId));
+	public ResponseEntity<List<TheaterSeatResponse>> getSeats(@PathVariable Long theaterId) {
+		return ResponseEntity.ok(theaterSeatService.getSeats(theaterId));
 	}
 }

--- a/src/main/java/com/example/seatchoice/dto/response/TheaterSeatResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/response/TheaterSeatResponse.java
@@ -1,11 +1,15 @@
 package com.example.seatchoice.dto.response;
 
 import com.example.seatchoice.entity.TheaterSeat;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.CollectionUtils;
 
 @Setter
 @Getter
@@ -13,23 +17,64 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TheaterSeatResponse {
-	private Long seatId;
-	private Integer floor;
-	private String section;
-	private String seatRow;
-	private Integer seatNumber;
-	private Long reviewAmount;
-	private Double rating; // 평점
 
-	public static TheaterSeatResponse from(TheaterSeat seat) {
+	private Integer floor;
+	private List<Section> sections;
+
+	public static TheaterSeatResponse from(Integer floor, List<Section> sections) {
 		return TheaterSeatResponse.builder()
-			.seatId(seat.getId())
-			.floor(seat.getFloor())
-			.section(seat.getSection())
-			.seatRow(seat.getSeatRow())
-			.seatNumber(seat.getNumber())
-			.reviewAmount(seat.getReviewAmount())
-			.rating(seat.getRating())
+			.floor(floor)
+			.sections(sections)
 			.build();
+	}
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Section {
+
+		private String section;
+		private List<Seat> seats;
+
+		public static Section from(String section, List<Seat> seats) {
+			return Section.builder()
+				.section(section)
+				.seats(seats)
+				.build();
+		}
+	}
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Seat {
+
+		private Long seatId;
+		private String seatRow;
+		private Integer seatNumber;
+		private Long reviewAmount;
+		private Double rating;
+
+		private static Seat from(TheaterSeat theaterSeat) {
+			return Seat.builder()
+				.seatId(theaterSeat.getId())
+				.seatRow(theaterSeat.getSeatRow())
+				.seatNumber(theaterSeat.getNumber())
+				.reviewAmount(theaterSeat.getReviewAmount())
+				.rating(theaterSeat.getRating())
+				.build();
+		}
+
+		public static List<Seat> of(Integer floor, String section, List<TheaterSeat> theaterSeats) {
+			if (CollectionUtils.isEmpty(theaterSeats)) {
+				return Collections.emptyList();
+			}
+			return theaterSeats.stream()
+				.filter(t -> t.getFloor() == floor && t.getSection().equals(section))
+				.map(Seat::from)
+				.collect(Collectors.toList());
+		}
 	}
 }

--- a/src/main/java/com/example/seatchoice/repository/TheaterSeatRepository.java
+++ b/src/main/java/com/example/seatchoice/repository/TheaterSeatRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TheaterSeatRepository extends JpaRepository<TheaterSeat, Long> {
+public interface TheaterSeatRepository extends JpaRepository<TheaterSeat, Long>,
+	TheaterSeatRepositoryCustom {
+
 	List<TheaterSeat> findAllByTheaterId(Long id);
 }

--- a/src/main/java/com/example/seatchoice/repository/TheaterSeatRepositoryCustom.java
+++ b/src/main/java/com/example/seatchoice/repository/TheaterSeatRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.seatchoice.repository;
+
+import java.util.List;
+
+public interface TheaterSeatRepositoryCustom {
+
+	List<Integer> findDistinctFloorByTheaterId(Long theaterId);
+
+	List<String> findDistinctSectionByTheaterId(Long theaterId);
+}

--- a/src/main/java/com/example/seatchoice/repository/TheaterSeatRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/TheaterSeatRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.example.seatchoice.repository;
+
+import static com.example.seatchoice.entity.QTheaterSeat.theaterSeat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class TheaterSeatRepositoryImpl implements TheaterSeatRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Integer> findDistinctFloorByTheaterId(Long theaterId) {
+		List<Integer> floors = queryFactory
+			.select(theaterSeat.floor).distinct()
+			.from(theaterSeat)
+			.where(theaterSeat.theater.id.eq(theaterId))
+			.fetch();
+
+		if (CollectionUtils.isEmpty(floors)) {
+			return Collections.emptyList();
+		}
+		return floors;
+	}
+
+	@Override
+	public List<String> findDistinctSectionByTheaterId(Long theaterId) {
+		List<String> sections = queryFactory
+			.select(theaterSeat.section).distinct()
+			.from(theaterSeat)
+			.where(theaterSeat.theater.id.eq(theaterId))
+			.fetch();
+
+		if (CollectionUtils.isEmpty(sections)) {
+			return Collections.emptyList();
+		}
+		return sections;
+	}
+}

--- a/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
@@ -3,26 +3,41 @@ package com.example.seatchoice.service;
 import com.example.seatchoice.dto.response.TheaterSeatResponse;
 import com.example.seatchoice.entity.TheaterSeat;
 import com.example.seatchoice.repository.TheaterSeatRepository;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TheaterSeatService {
 
 	private final TheaterSeatRepository theaterSeatRepository;
-	public List<TheaterSeatResponse> getSeatsWithReviews(Long theaterId) {
-		List<TheaterSeat> seats = theaterSeatRepository.findAllByTheaterId(theaterId);
 
-		if (!CollectionUtils.isEmpty(seats)) {
-			return seats.stream()
-				.filter(t -> t.getReviewAmount() > 0)
-				.map(TheaterSeatResponse::from)
-				.collect(Collectors.toList());
+	public List<TheaterSeatResponse> getSeats(Long theaterId) {
+		List<Integer> floorList = theaterSeatRepository.findDistinctFloorByTheaterId(theaterId);
+		if (CollectionUtils.isEmpty(floorList)) {
+			return Collections.emptyList();
 		}
-		return null;
+
+		List<String> sectionList = theaterSeatRepository.findDistinctSectionByTheaterId(theaterId);
+		List<TheaterSeatResponse.Section> sections;
+		List<TheaterSeatResponse> theaterSeatResponses = new ArrayList<>();
+		List<TheaterSeat> theaterSeats = theaterSeatRepository.findAllByTheaterId(theaterId);
+
+		for (Integer floor : floorList) {
+			sections = new ArrayList<>();
+			for (String section : sectionList) {
+				sections.add(TheaterSeatResponse.Section.from(section,
+					TheaterSeatResponse.Seat.of(floor, section, theaterSeats)));
+			}
+			theaterSeatResponses.add(TheaterSeatResponse.from(floor, sections));
+		}
+
+		return theaterSeatResponses;
 	}
 }

--- a/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
+++ b/src/main/java/com/example/seatchoice/service/TheaterSeatService.java
@@ -24,6 +24,11 @@ public class TheaterSeatService {
 			return Collections.emptyList();
 		}
 
+		return getTheaterSeatResponses(floorList, theaterId);
+	}
+
+	private List<TheaterSeatResponse> getTheaterSeatResponses(List<Integer> floorList,
+		Long theaterId) {
 		List<String> sectionList = theaterSeatRepository.findDistinctSectionByTheaterId(theaterId);
 		List<TheaterSeatResponse.Section> sections;
 		List<TheaterSeatResponse> theaterSeatResponses = new ArrayList<>();

--- a/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
+++ b/src/test/java/com/example/seatchoice/service/TheaterSeatServiceTest.java
@@ -8,6 +8,7 @@ import com.example.seatchoice.dto.response.TheaterSeatResponse;
 import com.example.seatchoice.entity.TheaterSeat;
 import com.example.seatchoice.repository.TheaterSeatRepository;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,11 @@ public class TheaterSeatServiceTest {
 	private TheaterSeatService theaterSeatService;
 
 	@Test
-	@DisplayName("리뷰가 있는 좌석 조회 성공 - 좌석이 있을 경우")
-	void getSeatsWithReviewsSuccess() {
+	@DisplayName("전체 좌석 조회 성공 - 좌석이 있을 경우")
+	void getSeatSuccess() {
 		// given
+		List<Integer> floorList = Arrays.asList(1, 2);
+		List<String> sectionList = Arrays.asList("OP", "A");
 		List<TheaterSeat> seats = Arrays.asList(
 			TheaterSeat.builder()
 				.floor(1)
@@ -49,26 +52,29 @@ public class TheaterSeatServiceTest {
 				.build()
 		);
 
+		given(theaterSeatRepository.findDistinctFloorByTheaterId(anyLong())).willReturn(floorList);
+		given(theaterSeatRepository.findDistinctSectionByTheaterId(anyLong())).willReturn(
+			sectionList);
 		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(seats);
 
 		// when
-		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeatsWithReviews(1L);
+		List<TheaterSeatResponse> theaterSeatResponses = theaterSeatService.getSeats(1L);
 
 		// then
-		assertEquals(1, seatsWithReviews.size());
-		assertEquals(2, seatsWithReviews.get(0).getFloor());
+		assertEquals(2, theaterSeatResponses.size());
+		assertEquals(1, theaterSeatResponses.get(0).getFloor());
 	}
 
 	@Test
-	@DisplayName("리뷰가 있는 좌석 조회 성공 - 좌석이 없을 경우")
-	void getSeatsWithReviews_noSeats() {
+	@DisplayName("전체 좌석 조회 성공 - 좌석이 없을 경우")
+	void getSeats_noSeats() {
 		// given
-		given(theaterSeatRepository.findAllByTheaterId(anyLong())).willReturn(null);
+		given(theaterSeatRepository.findDistinctFloorByTheaterId(anyLong())).willReturn(null);
 
 		// when
-		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeatsWithReviews(1L);
+		List<TheaterSeatResponse> seatsWithReviews = theaterSeatService.getSeats(1L);
 
 		// then
-		assertEquals(null, seatsWithReviews);
+		assertEquals(Collections.emptyList(), seatsWithReviews);
 	}
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 기존 리뷰가 있는 좌석 조회를 전체 좌석 조회로 변경(api 그대로 진행)
  - 전체 공연장 형식에 적용할 수 있도록 코드 구현
  - querydsl을 사용하여 distinct한 floor Integer list와 section String list 호출
  - 모든 공연장 좌석에 대한 정보 조회 시 총 db 쿼리 3번 발생(고정된 횟수)
  - 좌석이 없을 때 빈 list 값 반환
  - 코드 실행 시간 구해봤는데 0초 나왔습니다! 그래서 for문은 성능에 크게 영향을 미치지 않는 거 같습니다.
  - 테스트코드 구현

**TheaterSeatReponse** 부분 코드 괜찮은지 확인해주세요!!!
  - java 파일을 아예 따로 만드는 게 좋을지 아님 이대로 진행하는 게 좋을지 고민됩니다. 
    TheaterSeatResponse, Seat, Section 모두 연관된 class고, Seat과 Section이 TheaterSeatResponse에 종속되므로 한 java 파일에 class를 생성했는데 어떻게 하면 더 좋을지 의견 주세요!!!  

**TO-BE**
- 리뷰 리팩토링
- exception 발생 시, s3에 저장된 이미지 삭제 구현 

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
