### PR TITLE
fix : list null 반환을 emptyList() 반환으로 수정

### DIFF
--- a/src/main/java/com/example/seatchoice/dto/response/ReviewInfoResponse.java
+++ b/src/main/java/com/example/seatchoice/dto/response/ReviewInfoResponse.java
@@ -1,6 +1,7 @@
 package com.example.seatchoice.dto.response;
 
 import com.example.seatchoice.entity.Review;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.util.CollectionUtils;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewInfoResponse {
+
 	private Double seatRating; // 좌석 평점
 	private Long reviewId;
 	private Long userId;
@@ -48,7 +50,7 @@ public class ReviewInfoResponse {
 
 	public static List<ReviewInfoResponse> of(List<Review> reviews) {
 		if (CollectionUtils.isEmpty(reviews)) {
-			return null;
+			return Collections.emptyList();
 		}
 		return reviews.stream()
 			.map(ReviewInfoResponse::from)

--- a/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/seatchoice/repository/reviewPaging/ReviewRepositoryImpl.java
@@ -12,10 +12,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
 
 @Repository
 @RequiredArgsConstructor
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+
 	private final JPAQueryFactory queryFactory;
 
 	@Override
@@ -32,8 +34,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 			.fetch();
 
 		List<ReviewInfoResponse> reviewInfoResponses = ReviewInfoResponse.of(reviews);
-		if (reviewInfoResponses == null) {
-			return null;
+		if (CollectionUtils.isEmpty(reviewInfoResponses)) {
+			return new SliceImpl<>(reviewInfoResponses, pageable, false);
 		}
 		return checkLastPage(pageable, reviewInfoResponses);
 	}
@@ -46,7 +48,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 		return review.id.lt(reviewId);
 	}
 
-	private Slice<ReviewInfoResponse> checkLastPage(Pageable pageable, List<ReviewInfoResponse> results) {
+	private Slice<ReviewInfoResponse> checkLastPage(Pageable pageable,
+		List<ReviewInfoResponse> results) {
 		boolean hasNext = false;
 		// 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
 		if (results.size() > pageable.getPageSize()) {


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 기존 list 값이 비어있을 때 null 반환에서 Collections.emptyList()을 이용하여 빈 리스트 반환
 
**TO-BE**

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
